### PR TITLE
Adding postgres as db instead of sqllite 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 node_modules/
 env/
 **/*.pyc
+.env

--- a/djreact/settings.py
+++ b/djreact/settings.py
@@ -1,6 +1,11 @@
 import os
-
+import dj_database_url
+import dotenv
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+dotenv_file = os.path.join(BASE_DIR, ".env")
+if os.path.isfile(dotenv_file):
+    dotenv.load_dotenv(dotenv_file)
 SECRET_KEY = '-05sgp9!deq=q1nltm@^^2cc+v29i(tyybv3v2t77qi66czazj'
 DEBUG = True
 ## update these to include the current domain names
@@ -61,12 +66,14 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'djreact.wsgi.application'
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
-}
+# DATABASES = {
+#     'default': {
+#         'ENGINE': 'django.db.backends.sqlite3',
+#         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+#     }
+# }
+DATABASES = {}
+DATABASES['default'] = dj_database_url.config(conn_max_age=600)
 
 AUTH_PASSWORD_VALIDATORS = [
     {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'},

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ asgiref==3.2.3
 certifi==2019.11.28
 chardet==3.0.4
 defusedxml==0.6.0
+dj-database-url==0.5.0
 Django==3.0.2
 django-allauth==0.41.0
 django-cors-headers==3.2.1
@@ -10,6 +11,8 @@ djangorestframework==3.11.0
 gunicorn==20.0.4
 idna==2.8
 oauthlib==3.1.0
+psycopg2-binary==2.8.4
+python-dotenv==0.10.4
 python3-openid==3.1.0
 pytz==2019.3
 requests==2.22.0


### PR DESCRIPTION
To run locally, need to create a .env file in the root directory and add the config with the following command: (you will also need to download the heroku CLI)
`heroku config:get DATABASE_URL -s -a rack-city-dev >> .env`