### PR TITLE
fixed no data bug

### DIFF
--- a/src/components/elementView/elementView.scss
+++ b/src/components/elementView/elementView.scss
@@ -6,46 +6,13 @@
   outline: none;
 }
 
-// .table {
-//     border-spacing: 0;
-//     border: 0px solid #ededed;
-//   }
-//   table tr:last-child td {
-//     border-bottom: 0;
-//   }
-//   table th,
-//   table td {
-//     margin: 0;
-//     padding: 0.5rem;
-//     border-bottom: 1px solid #ededed;
-//     border-right: 20px solid #ededed;
-//     position: relative;
-//   }
-//   table th:last-child,
-//   table td:last-child {
-//     border-right: 0;
-//   }
-//   .table tr:nth-child(even) {
-//     background-color:grey;
-//   }
-
-//   table th::before {
-//     position: absolute;
-//     right: 15px;
-//     top: 16px;
-//     content: "";
-//     width: 0;
-//     height: 0;
-//     border-left: 5px solid transparent;
-//     border-right: 5px solid transparent;
-//   }
-//   table th.sort-asc::before {
-//     border-bottom: 5px solid #22543d;
-//   }
-//   table th.sort-desc::before {
-//     border-top: 5px solid #22543d;
-//   }
-
+.loading-container {
+  text-align: center;
+}
+.center {
+  display: inline-block;
+  padding: 10px;
+}
 .TableView {
   display: flex;
   flex-direction: column;

--- a/src/components/elementView/elementView.tsx
+++ b/src/components/elementView/elementView.tsx
@@ -1,9 +1,9 @@
-import { Classes, Tab, Tabs } from "@blueprintjs/core";
+import { Classes, Spinner, Tab, Tabs } from "@blueprintjs/core";
 import "@blueprintjs/core/lib/css/blueprint.css";
 import axios from "axios";
-import { API_ROOT } from "../../api-config";
 import * as React from "react";
 import { RouteComponentProps, withRouter } from "react-router";
+import { API_ROOT } from "../../api-config";
 import "./elementView.scss";
 
 //export interface ElementViewProps {}
@@ -79,15 +79,28 @@ export class ElementTable extends React.Component<
 
   async componentDidMount() {
     const resp = await getData(this.props.element);
+    console.log(resp.cols);
+    const cols = resp.cols.length === 0 ? [] : resp.cols[0];
 
     this.setState({
-      columns: resp.cols[0],
+      columns: cols,
 
       data: resp.data
     });
   }
   public render() {
-    return (
+    console.log(this.props.element);
+    return this.state.columns.length === 0 ? (
+      <div className="loading-container">
+        <p className="center">No {this.props.element} data found </p>
+        <p></p>
+        <Spinner
+          className="center"
+          intent="primary"
+          size={Spinner.SIZE_STANDARD}
+        />
+      </div>
+    ) : (
       <div className="ElementTable">
         <table className="bp3-html-table bp3-interactive bp3-html-table-striped bp3-html-table-bordered">
           <thead>


### PR DESCRIPTION
Before, if no data was being returned on models/racks/instances, front end was failing to load anything on the landing page. Should now display "no data found" and a spinner icon. This was only discovered when we deployed on staging because staging db has no data in it.