### PR TITLE
Defining new types for assets

### DIFF
--- a/src/components/elementView/detailedView/assetView/assetView.tsx
+++ b/src/components/elementView/detailedView/assetView/assetView.tsx
@@ -16,7 +16,7 @@ import { RouteComponentProps, withRouter } from "react-router";
 import "./assetView.scss";
 import { connect } from "react-redux";
 import {
-  AssetObject,
+  AssetObjectOld,
   ElementType,
   getHeaders,
   getFields
@@ -49,7 +49,7 @@ async function getData(assetkey: string, token: string) {
 }
 
 interface AssetViewState {
-  asset: AssetObject | undefined;
+  asset: AssetObjectOld | undefined;
   columns: Array<string>;
   fields: Array<string>;
   isFormOpen: boolean;
@@ -69,7 +69,7 @@ export class AssetView extends React.PureComponent<
     columns: ["Hostname", "Model", "Rack", "Rack position", "Owner", "Comment"],
     fields: ["hostname", "model", "rack", "Rack position", "owner", "comment"]
   };
-  private updateAsset = (asset: AssetObject, headers: any): Promise<any> => {
+  private updateAsset = (asset: AssetObjectOld, headers: any): Promise<any> => {
     let params: any;
     params = this.props.match.params;
     return modifyAsset(asset, headers).then(res => {

--- a/src/components/elementView/detailedView/modelView/modelView.tsx
+++ b/src/components/elementView/detailedView/modelView/modelView.tsx
@@ -20,7 +20,7 @@ import FormPopup from "../../../../forms/formPopup";
 import ElementTable from "../../elementTable";
 import {
   ElementType,
-  AssetObject,
+  AssetObjectOld,
   ModelObject,
   getHeaders,
   getFields
@@ -38,7 +38,7 @@ export interface ModelViewProps {
 // var console: any = {};
 // console.log = function () { };
 interface ModelViewState {
-  assets: Array<AssetObject> | undefined;
+  assets: Array<AssetObjectOld> | undefined;
   model: ModelObject | undefined;
   columns: Array<string>;
   fields: Array<string>;

--- a/src/components/elementView/detailedView/rackView/rackView.tsx
+++ b/src/components/elementView/detailedView/rackView/rackView.tsx
@@ -15,7 +15,7 @@ import { RouteComponentProps, withRouter } from "react-router";
 import { API_ROOT } from "../../../../utils/api-config";
 import {
   getHeaders,
-  AssetObject,
+  AssetObjectOld,
   RackResponseObject
 } from "../../../../utils/utils";
 import "./rackView.scss";
@@ -48,7 +48,7 @@ class RackView extends React.PureComponent<
     let unit = 1;
     let currHeight = 0;
     const { height } = rackResp.rack;
-    let assets: Array<AssetObject> = Object.assign(
+    let assets: Array<AssetObjectOld> = Object.assign(
       [],
       rackResp.assets
     );

--- a/src/components/elementView/elementTab.tsx
+++ b/src/components/elementView/elementTab.tsx
@@ -25,7 +25,7 @@ import {
 } from "../../forms/formUtils";
 import { API_ROOT } from "../../utils/api-config";
 import {
-  AssetInfoObject,
+  ShallowAssetObject,
   CreateUserObject,
   ElementObjectType,
   ElementType,
@@ -166,7 +166,7 @@ class ElementTab extends React.Component<ElementTabProps, ElementViewState> {
   };
 
   private createAsset = (
-    asset: AssetInfoObject,
+    asset: ShallowAssetObject,
     headers: any
   ): Promise<any> => {
     console.log("api/assets/add");

--- a/src/components/elementView/elementUtils.tsx
+++ b/src/components/elementView/elementUtils.tsx
@@ -1,7 +1,7 @@
 import {
   RackRangeFields,
   ModelObject,
-  AssetObject,
+  AssetObjectOld,
   DatacenterObject
 } from "../../utils/utils";
 import { API_ROOT } from "../../utils/api-config";
@@ -81,12 +81,15 @@ export const deleteModel = (model: ModelObject, headers: any) => {
   const data = { id: model!.id };
   return axios.post(API_ROOT + "api/models/delete", data, headers);
 };
-export const deleteAsset = (asset: AssetObject, headers: any) => {
+export const deleteAsset = (asset: AssetObjectOld, headers: any) => {
   console.log("Deleting asset");
   const data = { id: asset.id };
   return axios.post(API_ROOT + "api/assets/delete", data, headers);
 };
-export const modifyAsset = (asset: AssetObject, headers: any): Promise<any> => {
+export const modifyAsset = (
+  asset: AssetObjectOld,
+  headers: any
+): Promise<any> => {
   return axios.post(API_ROOT + "api/assets/modify", asset, headers);
 };
 

--- a/src/components/import/import.tsx
+++ b/src/components/import/import.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { API_ROOT } from "../../utils/api-config";
 import { RouteComponentProps, withRouter } from "react-router";
 import { connect } from "react-redux";
-import { AssetObject, ModelObjectOld } from "../../utils/utils";
+import { AssetObjectOld, ModelObjectOld } from "../../utils/utils";
 import "./import.scss";
 import { FileSelector } from "../lib/fileSelect"
 import { Modifier } from "./viewModified"
@@ -24,7 +24,7 @@ interface AlertState {
   assetAlterationsIsOpen: boolean,
   selectedFile?: File,
   loadedModels?: Array<ModelObjectOld>,
-  loadedAssets?: Array<AssetObject>,
+  loadedAssets?: Array<AssetObjectOld>,
   modifiedModels?: Array<any>,
   modifiedAssets?: Array<any>,
   ignoredModels?: number,

--- a/src/forms/assetForm.tsx
+++ b/src/forms/assetForm.tsx
@@ -11,9 +11,9 @@ import * as React from "react";
 import { connect } from "react-redux";
 
 import {
-  AssetObject,
+  AssetObjectOld,
   ModelObject,
-  AssetInfoObject,
+  ShallowAssetObjectOld,
   getHeaders,
   RackObject,
   ElementObjectType
@@ -42,11 +42,11 @@ import { PagingTypes } from "../components/elementView/elementUtils";
 export interface AssetFormProps {
   token: string;
   type: FormTypes;
-  initialValues?: AssetObject;
-  submitForm(Asset: AssetInfoObject, headers: any): Promise<any> | void;
+  initialValues?: AssetObjectOld;
+  submitForm(Asset: ShallowAssetObjectOld, headers: any): Promise<any> | void;
 }
 interface AssetFormState {
-  values: AssetObject;
+  values: AssetObjectOld;
   racks: Array<RackObject>;
   models: Array<ModelObject>;
   errors: Array<string>;
@@ -56,8 +56,8 @@ var console: any = {};
 console.log = function() {};
 
 export const required = (
-  values: AssetObject,
-  fieldName: keyof AssetObject
+  values: AssetObjectOld,
+  fieldName: keyof AssetObjectOld
 ): string =>
   values[fieldName] === undefined ||
   values[fieldName] === null ||
@@ -66,9 +66,9 @@ export const required = (
     : "";
 
 class AssetForm extends React.Component<AssetFormProps, AssetFormState> {
-  initialState: AssetObject = this.props.initialValues
+  initialState: AssetObjectOld = this.props.initialValues
     ? this.props.initialValues
-    : ({} as AssetObject);
+    : ({} as AssetObjectOld);
   public state = {
     values: this.initialState,
     racks: [],
@@ -113,13 +113,13 @@ class AssetForm extends React.Component<AssetFormProps, AssetFormState> {
         return items;
       });
   }
-  private mapAssetObject = (asset: AssetObject): AssetInfoObject => {
+  private mapAssetObject = (asset: AssetObjectOld): ShallowAssetObjectOld => {
     console.log(asset);
 
     const { hostname, id, rack_position, owner, comment } = asset;
     const model = asset.model ? asset.model.id : undefined;
     const rack = asset.rack ? asset.rack.id : undefined;
-    let valuesToSend: AssetInfoObject = {
+    let valuesToSend: ShallowAssetObjectOld = {
       model,
       rack,
       hostname,

--- a/src/forms/formPopup.tsx
+++ b/src/forms/formPopup.tsx
@@ -14,7 +14,7 @@ import ModelForm from "./modelForm";
 import DatacenterForm from "./datacenterForm";
 import WrappedRegistrationForm from "./auth/register";
 import { FormTypes } from "./formUtils";
-interface FormPopupState { }
+interface FormPopupState {}
 interface FormPopupProps {
   isOpen: boolean;
   type: FormTypes;

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -10,13 +10,44 @@ export enum ElementType {
   USER = "users",
   DATACENTER = "datacenters"
 }
-export interface AssetObject extends ElementObject {
+export enum PowerSide {
+  LEFT = "L",
+  RIGHT = "R"
+}
+export interface AssetObjectOld extends ElementObject {
   hostname: string;
   rack_position: string;
   model: ModelObjectOld;
   rack: RackObject;
   owner?: string;
   comment?: string;
+}
+
+export interface ShallowAssetObjectOld extends ElementObject {
+  hostname: string;
+  rack_position: string;
+  model?: string;
+  rack?: string;
+  owner?: string;
+  comment?: string;
+}
+export interface AssetObject extends ParentAssetObject {
+  model: ModelObject;
+  rack: RackObject;
+}
+
+interface ParentAssetObject extends ElementObject {
+  hostname: string;
+  rack_position: string;
+  mac_addresses: { [port: string]: string };
+  network_connections: Array<NetworkConnection>;
+  power_connections: { [port: string]: PowerConnection };
+  owner?: string;
+  comment?: string;
+}
+export interface ShallowAssetObject extends ParentAssetObject {
+  model?: string;
+  rack?: string;
 }
 export interface RackRangeFields {
   datacenter: string;
@@ -26,15 +57,26 @@ export interface RackRangeFields {
   num_end: number;
 }
 
-export interface AssetInfoObject extends ElementObject {
-  hostname: string;
-  rack_position: string;
-  model?: string;
-  rack?: string;
-  owner?: string;
-  comment?: string;
+export interface NetworkConnection {
+  source_port: string;
+  destination_hostname: string;
+  destination_port: string;
+}
+export interface NetworkGraph {
+  nodes: { [hostname: string]: string };
+  links: Array<{ [source: string]: string }>;
+}
+export interface PowerConnection {
+  left_right: PowerSide;
+  port_number: string;
 }
 
+export interface PowerPortAvailability {
+  left_suggest: string;
+  left_available: Array<string>;
+  right_suggest: string;
+  right_available: Array<string>;
+}
 export interface UserInfoObject extends ElementObject {
   username: string;
   email?: string;
@@ -60,7 +102,7 @@ export interface RackObject extends ElementObject {
 
 export interface RackResponseObject {
   rack: RackObject;
-  assets: Array<AssetObject>;
+  assets: Array<AssetObjectOld>;
 }
 
 export interface DatacenterObject extends ElementObject {
@@ -101,26 +143,27 @@ export interface ModelObject extends ElementObject {
 }
 export interface ModelDetailObject {
   model: ModelObjectOld;
-  assets: Array<AssetObject>;
+  assets: Array<AssetObjectOld>;
 }
 export type ElementObjectType =
   | ModelObjectOld
   | ModelObject
   | RackObject
-  | AssetObject
-  | AssetInfoObject
+  | AssetObjectOld
+  | ShallowAssetObject
   | UserInfoObject
   | DatacenterObject;
 
 export type FormObjectType =
   | ModelObjectOld
   | RackObject
-  | AssetObject
+  | AssetObjectOld
   | DatacenterObject
   | RackRangeFields
-  | AssetInfoObject
+  | ShallowAssetObject
   | UserInfoObject
-  | CreateUserObject;
+  | CreateUserObject
+  | ShallowAssetObjectOld;
 export function isModelObject(obj: any): obj is ModelObject {
   return obj && obj.model_number;
 }
@@ -130,7 +173,7 @@ export function isDatacenterObject(obj: any): obj is DatacenterObject {
 export function isRackObject(obj: any): obj is RackObject {
   return obj && obj.rack_num;
 }
-export function isAssetObject(obj: any): obj is AssetObject {
+export function isAssetObject(obj: any): obj is AssetObjectOld {
   return obj && obj.hostname;
 }
 


### PR DESCRIPTION
- [x] AssetObject -> AssetObjectOld
- [x] AssetInfoObject -> ShallowAssetObjectOld
- [x] the UPDATED AssetInfoObject -> ShallowAssetObject

The new types have not been implemented anywhere -> i am using them on a diff branch for asset forms, but we should start using the new types for new features being developed/migrate away from the old objects. 