### PR TITLE
Connect grant/revoke admin endpoints to buttons

### DIFF
--- a/rackcity/utils/log_utils.py
+++ b/rackcity/utils/log_utils.py
@@ -81,7 +81,7 @@ def log_delete(user, element_type, element_name):
         element_name + ":",
         user.username,
         Action.DELETE.value,
-        element_type,
+        element_type.value,
         element_name
     ])
     log = Log(

--- a/src/components/elementView/elementTable.tsx
+++ b/src/components/elementView/elementTable.tsx
@@ -55,7 +55,6 @@ import {
   modifyDatacenter,
   ElementTableOpenAlert
 } from "./elementUtils";
-import { ELEVATION_0 } from "@blueprintjs/core/lib/esm/common/classes";
 
 interface ElementTableState {
   items: Array<ElementObjectType>;

--- a/src/components/elementView/elementTable.tsx
+++ b/src/components/elementView/elementTable.tsx
@@ -33,6 +33,8 @@ import {
 import DragDropList from "./dragDropList";
 import "./elementView.scss";
 import FilterSelect from "./filterSelect";
+import axios from "axios";
+import { API_ROOT } from "../../utils/api-config";
 
 import {
   ITableSort,
@@ -99,7 +101,7 @@ interface ElementTableProps {
 class ElementTable extends React.Component<
   ElementTableProps & RouteComponentProps,
   ElementTableState
-> {
+  > {
   public state: ElementTableState = {
     page_type: 10,
     filters: [],
@@ -227,7 +229,7 @@ class ElementTable extends React.Component<
         </span>
         <span>{`${item.field} by ${
           item.ascending ? "ascending" : "descending"
-        }`}</span>
+          }`}</span>
 
         <span>
           <Icon
@@ -648,6 +650,38 @@ class ElementTable extends React.Component<
   };
 
   //ADMIN BUTTON LOGIC
+  handleRevokeAdminButtonClick = (userid: string) => {
+    const headers = getHeaders(this.props.token)
+    axios
+      .post(API_ROOT + "api/users/revoke-admin", { "id": userid }, headers)
+      .then(res => {
+        console.log(res.data)
+      })
+      .catch(err => {
+        console.log(err);
+        this.addToast({
+          message: err.response.data.failure_message,
+          intent: Intent.DANGER
+        });
+      });
+  };
+
+  handleGrantAdminButtonClick = (userid: string) => {
+    const headers = getHeaders(this.props.token)
+    axios
+      .post(API_ROOT + "api/users/grant-admin", { "id": userid }, headers)
+      .then(res => {
+        console.log(res.data)
+      })
+      .catch(err => {
+        console.log(err);
+        this.addToast({
+          message: err.response.data.failure_message,
+          intent: Intent.DANGER
+        });
+      });
+  }
+
   renderAdminButton = (item: UserInfoObject) => {
     console.log(item.is_staff);
     if (item.is_staff) {
@@ -658,6 +692,7 @@ class ElementTable extends React.Component<
           icon="user"
           minimal
           text="Remove Admin"
+          onClick={() => this.handleRevokeAdminButtonClick(item.id)}
         />
       );
     } else {
@@ -669,6 +704,7 @@ class ElementTable extends React.Component<
           icon="user"
           minimal
           text="Add Admin "
+          onClick={() => this.handleGrantAdminButtonClick(item.id)}
         />
       );
     }
@@ -713,20 +749,20 @@ class ElementTable extends React.Component<
           {this.props.disableFiltering
             ? null
             : [
-                <div className="filter-select">
-                  <FilterSelect
-                    handleAddFilter={this.addFilter}
-                    fields={this.state.fields}
-                  />
-                </div>,
-                <div className="table-options">
-                  <p>Applied filters:</p>
-                  <DragDropList
-                    items={this.state.filters}
-                    renderItem={this.renderFilterItem}
-                  />
-                </div>
-              ]}
+              <div className="filter-select">
+                <FilterSelect
+                  handleAddFilter={this.addFilter}
+                  fields={this.state.fields}
+                />
+              </div>,
+              <div className="table-options">
+                <p>Applied filters:</p>
+                <DragDropList
+                  items={this.state.filters}
+                  renderItem={this.renderFilterItem}
+                />
+              </div>
+            ]}
           {this.props.disableSorting ? null : (
             <div className="table-options">
               <p>Applied sorts:</p>
@@ -750,26 +786,26 @@ class ElementTable extends React.Component<
               </HTMLSelect>
               {this.state.page_type !== PagingTypes.ALL
                 ? [
-                    <span>
-                      <Icon
-                        className="icon"
-                        icon={IconNames.CARET_LEFT}
-                        iconSize={Icon.SIZE_LARGE}
-                        onClick={() => this.previousPage()}
-                      />
-                    </span>,
-                    <span>
-                      page {this.state.curr_page} of {this.state.total_pages}
-                    </span>,
-                    <span>
-                      <Icon
-                        className="icon"
-                        icon={IconNames.CARET_RIGHT}
-                        iconSize={Icon.SIZE_LARGE}
-                        onClick={() => this.nextPage()}
-                      />
-                    </span>
-                  ]
+                  <span>
+                    <Icon
+                      className="icon"
+                      icon={IconNames.CARET_LEFT}
+                      iconSize={Icon.SIZE_LARGE}
+                      onClick={() => this.previousPage()}
+                    />
+                  </span>,
+                  <span>
+                    page {this.state.curr_page} of {this.state.total_pages}
+                  </span>,
+                  <span>
+                    <Icon
+                      className="icon"
+                      icon={IconNames.CARET_RIGHT}
+                      iconSize={Icon.SIZE_LARGE}
+                      onClick={() => this.nextPage()}
+                    />
+                  </span>
+                ]
                 : null}
             </div>
           ) : null}
@@ -779,7 +815,7 @@ class ElementTable extends React.Component<
             <table
               className={
                 this.props.type !== ElementType.DATACENTER &&
-                this.props.type !== ElementType.USER
+                  this.props.type !== ElementType.USER
                   ? "bp3-html-table bp3-interactive bp3-html-table-striped bp3-html-table-bordered element-table"
                   : "bp3-html-table bp3-html-table-striped bp3-html-table-bordered element-table"
               }
@@ -826,14 +862,14 @@ class ElementTable extends React.Component<
                       <tr
                         onClick={
                           this.props.type === ElementType.DATACENTER ||
-                          this.props.type === ElementType.USER
-                            ? () => {}
+                            this.props.type === ElementType.USER
+                            ? () => { }
                             : () => {
-                                console.log("redirecting", item.id);
-                                this.props.history.push(
-                                  "/" + this.props.type + "/" + item.id
-                                );
-                              }
+                              console.log("redirecting", item.id);
+                              this.props.history.push(
+                                "/" + this.props.type + "/" + item.id
+                              );
+                            }
                         }
                       >
                         {Object.entries(item).map(([col, value]) => {
@@ -844,7 +880,7 @@ class ElementTable extends React.Component<
                             ];
                           } else if (isRackObject(value)) {
                             return (
-                              <td>{value.row_letter  + value.rack_num}</td>
+                              <td>{value.row_letter + value.rack_num}</td>
                             );
                           } else if (col === "display_color") {
                             console.log(value);
@@ -868,44 +904,44 @@ class ElementTable extends React.Component<
                         })}
                         <td>
                           {this.props.isAdmin &&
-                          this.props.type !== ElementType.USER ? (
-                            <div className="inline-buttons">
-                              <AnchorButton
-                                className="button-table"
-                                intent="primary"
-                                icon="edit"
-                                minimal
-                                onClick={(event: any) => {
-                                  this.handleEditButtonClick(item);
-                                  event.stopPropagation();
-                                }}
-                              />
-                              <AnchorButton
-                                className="button-table"
-                                intent="danger"
-                                minimal
-                                icon="trash"
-                                onClick={(event: any) => {
-                                  this.handleDeleteButtonClick(item);
-                                  event.stopPropagation();
-                                }}
-                              />
-                              {this.props.isAdmin &&
-                              isAssetObject(item) &&
-                              item.rack.is_network_controlled ? (
+                            this.props.type !== ElementType.USER ? (
+                              <div className="inline-buttons">
                                 <AnchorButton
                                   className="button-table"
-                                  intent="warning"
+                                  intent="primary"
+                                  icon="edit"
                                   minimal
-                                  icon="offline"
                                   onClick={(event: any) => {
-                                    this.handlePowerButtonClick(item);
+                                    this.handleEditButtonClick(item);
                                     event.stopPropagation();
                                   }}
                                 />
-                              ) : null}
-                            </div>
-                          ) : null}{" "}
+                                <AnchorButton
+                                  className="button-table"
+                                  intent="danger"
+                                  minimal
+                                  icon="trash"
+                                  onClick={(event: any) => {
+                                    this.handleDeleteButtonClick(item);
+                                    event.stopPropagation();
+                                  }}
+                                />
+                                {this.props.isAdmin &&
+                                  isAssetObject(item) &&
+                                  item.rack.is_network_controlled ? (
+                                    <AnchorButton
+                                      className="button-table"
+                                      intent="warning"
+                                      minimal
+                                      icon="offline"
+                                      onClick={(event: any) => {
+                                        this.handlePowerButtonClick(item);
+                                        event.stopPropagation();
+                                      }}
+                                    />
+                                  ) : null}
+                              </div>
+                            ) : null}{" "}
                           {/* TODO add logic for determining if isOwner for power button */}
                           {this.props.isAdmin && isUserObject(item) ? (
                             <div className="inline-buttons">
@@ -918,8 +954,8 @@ class ElementTable extends React.Component<
                   })}
                 </tbody>
               ) : (
-                <h4 className="no-data-text">no {this.props.type} found </h4>
-              )}
+                  <h4 className="no-data-text">no {this.props.type} found </h4>
+                )}
             </table>
           )}
         </div>

--- a/src/components/elementView/elementTable.tsx
+++ b/src/components/elementView/elementTable.tsx
@@ -656,6 +656,10 @@ class ElementTable extends React.Component<
       .post(API_ROOT + "api/users/revoke-admin", { "id": userid }, headers)
       .then(res => {
         console.log(res.data)
+        this.addToast({
+          message: res.data.success_message,
+          intent: Intent.PRIMARY
+        });
       })
       .catch(err => {
         console.log(err);
@@ -672,6 +676,10 @@ class ElementTable extends React.Component<
       .post(API_ROOT + "api/users/grant-admin", { "id": userid }, headers)
       .then(res => {
         console.log(res.data)
+        this.addToast({
+          message: res.data.success_message,
+          intent: Intent.PRIMARY
+        });
       })
       .catch(err => {
         console.log(err);

--- a/src/components/elementView/elementUtils.tsx
+++ b/src/components/elementView/elementUtils.tsx
@@ -12,6 +12,13 @@ export interface ITableSort {
   id: string;
 }
 
+export enum ElementTableOpenAlert {
+  NONE = "none",
+  DELETE = "delete",
+  GRANT_ADMIN = "grant_admin",
+  REVOKE_ADMIN = "revoke_admin"
+}
+
 export enum FilterTypes {
   TEXT = "text",
   NUMERIC = "numeric",


### PR DESCRIPTION
- When click "Remove Admin" or "Add Admin" on a user table, confirmation dialog appears, then toast displays outcome, and table updates
- Also fixed a bug coming from LOGGING delete actions that was messing with delete actions
