### PR TITLE
Fail if try to delete netid user

### DIFF
--- a/rackcity/utils/user_utils.py
+++ b/rackcity/utils/user_utils.py
@@ -1,0 +1,8 @@
+def is_netid_user(user):
+    """
+    Returns true if user is Duke SSO authenticated NetID user.
+    Determined by whether the user has a non-empty password, since
+    NetID users are authenticated by access token and their associated
+    passwords are empty strings.
+    """
+    return (not user.password)

--- a/rackcity/views/user_views.py
+++ b/rackcity/views/user_views.py
@@ -4,6 +4,7 @@ from django.http import JsonResponse
 from http import HTTPStatus
 import math
 from rackcity.api.serializers import RegisterNameSerializer, UserSerializer
+from rackcity.utils.user_utils import is_netid_user
 import requests
 from rest_framework.authtoken.models import Token
 from rest_framework.decorators import permission_classes, api_view
@@ -153,10 +154,11 @@ def user_delete(request):
             },
             status=HTTPStatus.BAD_REQUEST,
         )
-    if not existing_user.password:
+    if is_netid_user(existing_user):
         return JsonResponse(
             {
-                "failure_message": "Cannot delete Duke SSO authenticated users."
+                "failure_message":
+                "Duke SSO authenticated users cannot be deleted."
             },
             status=HTTPStatus.BAD_REQUEST,
         )

--- a/rackcity/views/user_views.py
+++ b/rackcity/views/user_views.py
@@ -153,6 +153,13 @@ def user_delete(request):
             },
             status=HTTPStatus.BAD_REQUEST,
         )
+    if not existing_user.password:
+        return JsonResponse(
+            {
+                "failure_message": "Cannot delete Duke SSO authenticated users."
+            },
+            status=HTTPStatus.BAD_REQUEST,
+        )
     username = existing_user.username
     if username == 'admin':
         return JsonResponse(


### PR DESCRIPTION
In the ev2 spec: "Administrators can create and delete “local” (non-NetID) user accounts."