### PR TITLE
Rack fixes

### DIFF
--- a/src/components/elementView/elementTab.tsx
+++ b/src/components/elementView/elementTab.tsx
@@ -45,7 +45,7 @@ import { updateObject } from "../../store/utility";
 import { ALL_DATACENTERS } from "./elementTabContainer";
 
 var console: any = {};
-console.log = function () { };
+console.log = function() {};
 const fs = require("js-file-download");
 
 interface ElementViewState {
@@ -62,6 +62,7 @@ interface ElementViewProps {
   datacenters?: Array<DatacenterObject>;
   currDatacenter?: DatacenterObject;
   onDatacenterSelect?(datacenter: DatacenterObject): void;
+  updateDatacenters?(): void;
 }
 export function getPages(
   path: string,
@@ -132,9 +133,9 @@ class ElementTab extends React.Component<ElementTabProps, ElementViewState> {
       page_type === PagingTypes.ALL
         ? {}
         : {
-          page_size: page_type,
-          page
-        };
+            page_size: page_type,
+            page
+          };
     const config = {
       headers: {
         Authorization: "Token " + token
@@ -214,6 +215,10 @@ class ElementTab extends React.Component<ElementTabProps, ElementViewState> {
         this.handleDataUpdate(true);
         this.handleClose();
         this.addSuccessToast("Successfully created datacenter!");
+        if (this.props.updateDatacenters) {
+          this.props.updateDatacenters();
+        }
+
         console.log(this.state.isOpen);
       });
   };
@@ -276,7 +281,7 @@ class ElementTab extends React.Component<ElementTabProps, ElementViewState> {
                     rightIcon="caret-down"
                     text={
                       this.props.currDatacenter &&
-                        this.props.currDatacenter.name
+                      this.props.currDatacenter.name
                         ? this.props.currDatacenter.name
                         : "All datacenters"
                     }
@@ -289,32 +294,32 @@ class ElementTab extends React.Component<ElementTabProps, ElementViewState> {
 
         <div className="element-tab-buttons">
           {this.props.element !== ElementType.USER &&
-            this.props.element !== ElementType.DATACENTER ? (
-              <AnchorButton
-                className="add"
-                text="Export Table Data"
-                icon="import"
-                minimal
-                onClick={() => {
-                  /* handle data based on state */
-                  this.setState({ fileNameIsOpen: true });
-                  console.log(this.state.filters);
-                }}
-              />
-            ) : (
-              <p></p>
-            )}
+          this.props.element !== ElementType.DATACENTER ? (
+            <AnchorButton
+              className="add"
+              text="Export Table Data"
+              icon="import"
+              minimal
+              onClick={() => {
+                /* handle data based on state */
+                this.setState({ fileNameIsOpen: true });
+                console.log(this.state.filters);
+              }}
+            />
+          ) : (
+            <p></p>
+          )}
           {this.props.isAdmin &&
-            this.props.element !== ElementType.USER &&
-            this.props.element !== ElementType.DATACENTER ? (
-              <AnchorButton
-                onClick={() => this.props.history.push("/bulk-upload")}
-                className="add"
-                icon="export"
-                text="Add from CSV file"
-                minimal
-              />
-            ) : null}
+          this.props.element !== ElementType.USER &&
+          this.props.element !== ElementType.DATACENTER ? (
+            <AnchorButton
+              onClick={() => this.props.history.push("/bulk-upload")}
+              className="add"
+              icon="export"
+              text="Add from CSV file"
+              minimal
+            />
+          ) : null}
 
           <Alert
             cancelButtonText="Cancel"
@@ -371,10 +376,10 @@ class ElementTab extends React.Component<ElementTabProps, ElementViewState> {
               this.props.element === ElementType.MODEL
                 ? this.createModel
                 : this.props.element === ElementType.ASSET
-                  ? this.createAsset
-                  : this.props.element === ElementType.DATACENTER
-                    ? this.createDatacenter
-                    : this.createUser
+                ? this.createAsset
+                : this.props.element === ElementType.DATACENTER
+                ? this.createDatacenter
+                : this.createUser
             }
             isOpen={this.state.isOpen}
             handleClose={this.handleClose}
@@ -383,6 +388,7 @@ class ElementTab extends React.Component<ElementTabProps, ElementViewState> {
 
         <div>
           <ElementTable
+            updateDatacenters={this.props.updateDatacenters}
             type={this.props.element}
             getData={this.getElementData}
             getPages={getPages}
@@ -390,12 +396,8 @@ class ElementTab extends React.Component<ElementTabProps, ElementViewState> {
               this.setState({ filters: data });
             }}
             shouldUpdateData={this.state.updateTable}
-            disableSorting={
-              this.props.element === ElementType.DATACENTER
-            }
-            disableFiltering={
-              this.props.element === ElementType.DATACENTER
-            }
+            disableSorting={this.props.element === ElementType.DATACENTER}
+            disableFiltering={this.props.element === ElementType.DATACENTER}
             currDatacenter={this.props.currDatacenter}
           />
         </div>

--- a/src/components/elementView/elementTabContainer.tsx
+++ b/src/components/elementView/elementTabContainer.tsx
@@ -38,8 +38,8 @@ class ElementTabContainer extends React.Component<
       currDatacenter: datacenter
     });
   };
-  getDatacenters = (token: string) => {
-    const headers = getHeaders(token);
+  getDatacenters = () => {
+    const headers = getHeaders(this.props.token);
     // console.log(API_ROOT + "api/datacenters/get-all");
     axios
       .post(API_ROOT + "api/datacenters/get-many", {}, headers)
@@ -56,7 +56,7 @@ class ElementTabContainer extends React.Component<
       });
   };
   componentDidMount = () => {
-    this.getDatacenters(this.props.token);
+    this.getDatacenters();
   };
   public render() {
     return (
@@ -109,7 +109,11 @@ class ElementTabContainer extends React.Component<
             id="datacenter"
             title="Datacenters"
             panel={
-              <ElementTab {...this.props} element={ElementType.DATACENTER} />
+              <ElementTab
+                {...this.props}
+                updateDatacenters={this.getDatacenters}
+                element={ElementType.DATACENTER}
+              />
             }
           />
         ) : null}

--- a/src/components/elementView/elementUtils.tsx
+++ b/src/components/elementView/elementUtils.tsx
@@ -79,7 +79,15 @@ export const renderNumericFilterItem = (item: NumericFilter) => {
   return `between ${item.min} - ${item.max}`;
 };
 export const renderRackRangeFilterItem = (item: RackRangeFields) => {
-  return `rows  ${item.letter_start} - ${item.letter_end} & racks ${item.num_start} - ${item.num_end}`;
+  if (item.letter_end && item.num_end) {
+    return `rows  ${item.letter_start} - ${item.letter_end} & letters ${item.num_start} - ${item.num_end}`;
+  } else if (item.letter_end) {
+    return `rows  ${item.letter_start} - ${item.letter_end} & letters ${item.num_start}`;
+  } else if (item.num_end) {
+    return `row  ${item.letter_start}  & letters ${item.num_start} - ${item.num_end}`;
+  } else {
+    return ` ${item.letter_start}${item.num_start} `;
+  }
 };
 
 export const modifyModel = (model: ModelObject, headers: any) => {

--- a/src/components/elementView/elementView.scss
+++ b/src/components/elementView/elementView.scss
@@ -127,12 +127,7 @@
   text-transform: uppercase;
 }
 .or {
-  margin-top: -30pt;
-}
-.rack-field {
-  float: left;
-  padding: 0;
-  margin: 0;
+  margin-top: 10pt;
 }
 
 .tab {
@@ -144,10 +139,7 @@
 .element-tab table {
   width: 100%;
 }
-.rack-field .button {
-  float: left;
-  margin-top: 20px;
-}
+
 .header-text icon {
   float: right;
 }

--- a/src/components/elementView/elementView.scss
+++ b/src/components/elementView/elementView.scss
@@ -34,6 +34,13 @@
   // display: inline-block;
   table-layout: auto;
 }
+.rack-view-options {
+  display: inline-block;
+  text-align: center;
+}
+.all-racks {
+  height: fit-content;
+}
 .table-wrapper {
   width: 100%;
   overflow-x: scroll;
@@ -119,8 +126,13 @@
   font-weight: bold;
   text-transform: uppercase;
 }
+.or {
+  margin-top: -30pt;
+}
 .rack-field {
   float: left;
+  padding: 0;
+  margin: 0;
 }
 
 .tab {
@@ -156,6 +168,8 @@ input {
 
 .rack-select {
   float: left;
+  padding: 0;
+  margin: 0;
 }
 .table-control {
   float: right !important;

--- a/src/components/elementView/filterSelect.tsx
+++ b/src/components/elementView/filterSelect.tsx
@@ -20,8 +20,8 @@ import {
   getFilterType
 } from "./elementUtils";
 
-var console: any = {};
-console.log = function() {};
+// var console: any = {};
+// console.log = function() {};
 
 interface FilterSelectProps {
   token: string;
@@ -56,6 +56,7 @@ class FilterSelect extends React.Component<
     this.setState({});
   }
   getRackFilterOptions() {
+    console.log(this.state.filter);
     return this.state.filter && isRackRangeFields(this.state.filter) ? (
       <div className="field">
         <RackRangeForm
@@ -136,7 +137,7 @@ class FilterSelect extends React.Component<
       });
     }
     if (type === FilterTypes.RACKRANGE) {
-      const filter: RackRangeFields = {} as RackRangeFields;
+      const filter: RackRangeFields = { letter_start: "" } as RackRangeFields;
       this.setState({
         filter: filter
       });
@@ -165,6 +166,7 @@ class FilterSelect extends React.Component<
       id: this.state.field + JSON.stringify(this.state.filter)
     };
     console.log(filter);
+
     this.props.handleAddFilter(filter);
   };
   render() {

--- a/src/components/elementView/filterSelect.tsx
+++ b/src/components/elementView/filterSelect.tsx
@@ -10,7 +10,7 @@ import { filterString, renderStringItem } from "../../forms/formUtils";
 import { updateObject } from "../../store/utility";
 import "./elementView.scss";
 import RackRangeForm from "../../forms/rackRangeForm";
-import { RackRangeFields } from "../../utils/utils";
+import { RackRangeFields, isRackRangeFields } from "../../utils/utils";
 import {
   IFilter,
   FilterTypes,
@@ -36,7 +36,7 @@ class FilterSelect extends React.Component<
   state = {
     id: "",
     field: "",
-    filter: undefined,
+    filter: {} as TextFilter | NumericFilter | RackRangeFields,
     filter_type: FilterTypes.TEXT
   };
   renderFilterOptions(field: string | undefined) {
@@ -56,15 +56,15 @@ class FilterSelect extends React.Component<
     this.setState({});
   }
   getRackFilterOptions() {
-    return (
+    return this.state.filter && isRackRangeFields(this.state.filter) ? (
       <div className="field">
         <RackRangeForm
           className="field"
+          values={this.state.filter}
           handleChange={this.handleChange}
-          range={true}
         />
       </div>
-    );
+    ) : null;
   }
   getNumericFilterOptions() {
     return (

--- a/src/components/elementView/rackSelectView.tsx
+++ b/src/components/elementView/rackSelectView.tsx
@@ -69,34 +69,32 @@ class RackSelectView extends React.Component<
   render() {
     return (
       <div>
-        <div>
-          {this.state.errors.map((err: string) => {
-            return <Callout intent={Intent.DANGER}>{err}</Callout>;
-          })}
-          <form
-            onSubmit={this.handleSubmit}
-            className="create-form bp3-form-group"
-          >
-            <Switch
-              defaultChecked={false}
-              onChange={this.handleSwitchChange}
-              label="Rack Range"
+        {this.state.errors.map((err: string) => {
+          return <Callout intent={Intent.DANGER}>{err}</Callout>;
+        })}
+        <form
+          onSubmit={this.handleSubmit}
+          className="create-form bp3-form-group"
+        >
+          <Switch
+            defaultChecked={false}
+            onChange={this.handleSwitchChange}
+            label="Select Rack Range"
+          />
+          <div className="rack-select">
+            <RackRangeForm
+              className="rack-field"
+              handleChange={this.handleChange}
+              range={this.state.viewRange}
             />
-            <div className="rack-select">
-              <RackRangeForm
-                className="rack-field"
-                handleChange={this.handleChange}
-                range={this.state.viewRange}
-              />
 
-              <div className="rack-field ">
-                <Button className="button" type="submit">
-                  Submit
-                </Button>
-              </div>
+            <div className="rack-field ">
+              <Button className="button" type="submit">
+                Submit
+              </Button>
             </div>
-          </form>
-        </div>
+          </div>
+        </form>
       </div>
     );
   }

--- a/src/components/elementView/rackSelectView.tsx
+++ b/src/components/elementView/rackSelectView.tsx
@@ -21,7 +21,11 @@ console.log = function() {};
 interface RackSelectViewProps {
   token: string;
 
-  submitForm(model: RackRangeFields, headers: any): Promise<any> | void;
+  submitForm(
+    model: RackRangeFields,
+    headers: any,
+    showError: boolean
+  ): Promise<any> | void;
 }
 class RackSelectView extends React.Component<
   RackSelectViewProps & RouteComponentProps,
@@ -61,7 +65,7 @@ class RackSelectView extends React.Component<
     e.preventDefault();
 
     const headers = getHeaders(this.props.token);
-    const resp = this.props.submitForm(this.state.values, headers);
+    const resp = this.props.submitForm(this.state.values, headers, true);
     if (resp) {
       resp.catch(err => {
         console.log(err.response.data.failure_message);

--- a/src/components/elementView/rackSelectView.tsx
+++ b/src/components/elementView/rackSelectView.tsx
@@ -7,7 +7,11 @@ import { RouteComponentProps, withRouter } from "react-router";
 import "../../forms/forms.scss";
 import RackRangeForm from "../../forms/rackRangeForm";
 import { updateObject } from "../../store/utility";
-import { getHeaders, RackRangeFields } from "../../utils/utils";
+import {
+  getHeaders,
+  RackRangeFields,
+  DatacenterObject
+} from "../../utils/utils";
 import "./elementView.scss";
 interface RackSelectViewState {
   viewRange: boolean;
@@ -15,11 +19,12 @@ interface RackSelectViewState {
 
   errors: Array<string>;
 }
-var console: any = {};
-console.log = function() {};
+// var console: any = {};
+// console.log = function() {};
 
 interface RackSelectViewProps {
   token: string;
+  currDatacenter?: DatacenterObject;
 
   submitForm(
     model: RackRangeFields,
@@ -37,6 +42,21 @@ class RackSelectView extends React.Component<
 
     errors: []
   };
+  componentWillReceiveProps(nextProps: RackSelectViewProps) {
+    console.log(nextProps.currDatacenter, this.props.currDatacenter);
+    if (nextProps.currDatacenter !== this.props.currDatacenter) {
+      console.log("NEW DATACENTER", nextProps);
+      this.setState({
+        values: {
+          letter_start: "",
+          letter_end: "",
+          num_start: "",
+          num_end: "",
+          datacenter: ""
+        } as RackRangeFields
+      });
+    }
+  }
   private handleSwitchChange = handleBooleanChange(viewRange => {
     this.setState({ viewRange: viewRange });
     if (!viewRange) {
@@ -63,9 +83,15 @@ class RackSelectView extends React.Component<
     });
 
     e.preventDefault();
+    const values: any = this.state.values;
+    Object.entries(values).map(([field, value]) => {
+      if (value === "") {
+        values[field] = undefined;
+      }
+    });
 
     const headers = getHeaders(this.props.token);
-    const resp = this.props.submitForm(this.state.values, headers, true);
+    const resp = this.props.submitForm(values, headers, true);
     if (resp) {
       resp.catch(err => {
         console.log(err.response.data.failure_message);
@@ -81,6 +107,7 @@ class RackSelectView extends React.Component<
   componentDidMount() {}
 
   render() {
+    console.log(this.state.values);
     return (
       <div>
         {this.state.errors.map((err: string) => {
@@ -90,21 +117,16 @@ class RackSelectView extends React.Component<
           onSubmit={this.handleSubmit}
           className="create-form bp3-form-group"
         >
-          <Switch
-            defaultChecked={false}
-            onChange={this.handleSwitchChange}
-            label="Select Rack Range"
-          />
           <div className="rack-select">
             <RackRangeForm
               className="rack-field"
               handleChange={this.handleChange}
-              range={this.state.viewRange}
+              values={this.state.values}
             />
 
             <div className="rack-field ">
               <Button className="button" type="submit">
-                Submit
+                View Range of Racks
               </Button>
             </div>
           </div>

--- a/src/components/elementView/rackSelectView.tsx
+++ b/src/components/elementView/rackSelectView.tsx
@@ -126,7 +126,7 @@ class RackSelectView extends React.Component<
 
             <div className="rack-field ">
               <Button className="button" type="submit">
-                View Range of Racks
+                Submit
               </Button>
             </div>
           </div>

--- a/src/components/elementView/rackSelectView.tsx
+++ b/src/components/elementView/rackSelectView.tsx
@@ -61,7 +61,17 @@ class RackSelectView extends React.Component<
     e.preventDefault();
 
     const headers = getHeaders(this.props.token);
-    this.props.submitForm(this.state.values, headers);
+    const resp = this.props.submitForm(this.state.values, headers);
+    if (resp) {
+      resp.catch(err => {
+        console.log(err.response.data.failure_message);
+        let errors: Array<string> = this.state.errors;
+        errors.push(err.response.data.failure_message as string);
+        this.setState({
+          errors: errors
+        });
+      });
+    }
   };
   renderRackOptions(range: boolean) {}
   componentDidMount() {}

--- a/src/components/elementView/rackSelectView.tsx
+++ b/src/components/elementView/rackSelectView.tsx
@@ -1,4 +1,4 @@
-import { Button, Callout, Intent, Switch } from "@blueprintjs/core";
+import { Button, Callout, Intent } from "@blueprintjs/core";
 import "@blueprintjs/core/lib/css/blueprint.css";
 import { handleBooleanChange } from "@blueprintjs/docs-theme";
 import * as React from "react";
@@ -8,9 +8,9 @@ import "../../forms/forms.scss";
 import RackRangeForm from "../../forms/rackRangeForm";
 import { updateObject } from "../../store/utility";
 import {
+  DatacenterObject,
   getHeaders,
-  RackRangeFields,
-  DatacenterObject
+  RackRangeFields
 } from "../../utils/utils";
 import "./elementView.scss";
 interface RackSelectViewState {
@@ -84,7 +84,7 @@ class RackSelectView extends React.Component<
 
     e.preventDefault();
     const values: any = this.state.values;
-    Object.entries(values).map(([field, value]) => {
+    Object.entries(values).forEach(([field, value]) => {
       if (value === "") {
         values[field] = undefined;
       }

--- a/src/components/elementView/rackTab.tsx
+++ b/src/components/elementView/rackTab.tsx
@@ -25,7 +25,6 @@ import { API_ROOT } from "../../utils/api-config";
 import {
   DatacenterObject,
   ElementType,
-  getHeaders,
   RackRangeFields,
   RackResponseObject
 } from "../../utils/utils";
@@ -155,23 +154,30 @@ class RackTab extends React.Component<RackTabProps, RackTabState> {
       });
   };
 
-  getAllRacks = () => {
+  getAllRacks = (datacenter: DatacenterObject) => {
+    console.log(this.props);
     this.setState({
       loading: true
     });
+    const config = {
+      headers: {
+        Authorization: "Token " + this.props.token
+      },
+      params: {
+        datacenter: datacenter.id
+      }
+    };
     axios
-      .get(
-        API_ROOT + "api/racks/get-all",
-        // { sort_by: [], filters: [] },
-        getHeaders(this.props.token)
-      )
+      .get(API_ROOT + "api/racks/get-all", config)
       .then(res => {
+        console.log("GOT RACKS", res.data, this.state.racks);
         this.setState({
           racks: res.data.racks,
           loading: false
         });
       })
       .catch(err => {
+        console.log("failed to get racks");
         this.setState({
           loading: false,
           racks: []
@@ -274,12 +280,17 @@ class RackTab extends React.Component<RackTabProps, RackTabState> {
                 />
               </div>
             ) : null}
-            <Button
-              text="View All Rack(s)"
-              onClick={(e: any) => this.getAllRacks()}
-            />
-
-            <RackSelectView submitForm={this.viewRackForm} />
+            <div className="rack-view-options">
+              <RackSelectView submitForm={this.viewRackForm} />
+              <p className="or">or </p>
+              <Button
+                className="all-racks"
+                text="View All Racks"
+                onClick={(e: any) =>
+                  this.getAllRacks(this.props.currDatacenter)
+                }
+              />
+            </div>
           </div>
         ) : (
           <Callout intent={Intent.PRIMARY}>

--- a/src/components/elementView/rackTab.tsx
+++ b/src/components/elementView/rackTab.tsx
@@ -160,7 +160,14 @@ class RackTab extends React.Component<RackTabProps, RackTabState> {
       );
     }
   };
-
+  componentWillReceiveProps(nextProps: RackTabProps) {
+    if (nextProps.currDatacenter !== this.props.currDatacenter) {
+      this.setState({
+        racks: [],
+        selectedRackRange: {} as RackRangeFields
+      });
+    }
+  }
   createRack = (rack: RackRangeFields, headers: any) => {
     const rack_new = updateObject(rack, {
       datacenter: this.props.currDatacenter.id
@@ -304,14 +311,17 @@ class RackTab extends React.Component<RackTabProps, RackTabState> {
               </div>
             ) : null}
             <div className="rack-view-options">
-              <RackSelectView submitForm={this.viewRackForm} />
-              <p className="or">or </p>
               <Button
                 className="all-racks"
                 text="View All Racks"
                 onClick={(e: any) =>
                   this.getAllRacks(this.props.currDatacenter)
                 }
+              />
+              <p className="or">or </p>
+              <RackSelectView
+                currDatacenter={this.props.currDatacenter}
+                submitForm={this.viewRackForm}
               />
             </div>
           </div>

--- a/src/components/elementView/rackTab.tsx
+++ b/src/components/elementView/rackTab.tsx
@@ -112,8 +112,11 @@ class RackTab extends React.Component<RackTabProps, RackTabState> {
   };
 
   deleteRack = (rack: RackRangeFields, headers: any) => {
+    const rack_new = updateObject(rack, {
+      datacenter: this.props.currDatacenter.id
+    });
     this.setState({
-      deleteRackInfo: rack,
+      deleteRackInfo: rack_new,
       headers
     });
     this.handleConfirmationOpen();
@@ -143,8 +146,11 @@ class RackTab extends React.Component<RackTabProps, RackTabState> {
   };
 
   createRack = (rack: RackRangeFields, headers: any) => {
+    const rack_new = updateObject(rack, {
+      datacenter: this.props.currDatacenter.id
+    });
     return axios
-      .post(API_ROOT + "api/racks/create", rack, headers)
+      .post(API_ROOT + "api/racks/create", rack_new, headers)
       .then(res => {
         this.setState({ isOpen: false });
         this.addToast({

--- a/src/forms/forms.scss
+++ b/src/forms/forms.scss
@@ -12,6 +12,20 @@
 .login-container {
   text-align: center;
 }
+.rack-range .bp3-label {
+  min-width: 100pt;
+}
+.rack-range .bp3-input {
+  width: 50pt;
+  margin-right: 8pt;
+  margin-left: 8pt;
+}
+.rack-letter {
+  display: flex;
+}
+.dash {
+  margin-top: 5pt;
+}
 // textarea {
 //   background-color: #202b33;
 //   outline: none !important;

--- a/src/forms/rackRangeForm.tsx
+++ b/src/forms/rackRangeForm.tsx
@@ -1,48 +1,94 @@
 import { FormGroup } from "@blueprintjs/core";
 import * as React from "react";
 import Field from "./field";
+import { RackRangeFields } from "../utils/utils";
 interface RackRangeFormProps {
   handleChange(field: { [key: string]: any }): void;
-  range: boolean;
   className?: string;
+  values: RackRangeFields;
 }
-class RackRangeForm extends React.Component<RackRangeFormProps> {
+interface RackRangeFormState {
+  values: RackRangeFields;
+}
+
+class RackRangeForm extends React.Component<
+  RackRangeFormProps,
+  RackRangeFormState
+> {
+  public state = {
+    values: {} as RackRangeFields
+  };
+  componentDidMount = () => {
+    this.setState({
+      values: JSON.parse(JSON.stringify(this.props.values))
+    });
+  };
+  componentWillReceiveProps = (nextProps: RackRangeFormProps) => {
+    if (
+      JSON.stringify(nextProps.values) !== JSON.stringify(this.props.values)
+    ) {
+      console.log("new props", nextProps.values);
+      this.setState({
+        values: JSON.parse(JSON.stringify(nextProps.values))
+      });
+    }
+  };
   render() {
+    console.log("rack range form new values", this.state.values);
     return (
-      <div className={this.props.className}>
-        <FormGroup className={this.props.className} label="Row Letter ">
-          <Field
-            field="letter_start"
-            type="text"
-            onChange={this.props.handleChange}
-          />
-        </FormGroup>
-        {this.props.range ? (
-          <FormGroup className={this.props.className} label="Row Letter (end)">
+      <div className={this.props.className + " rack-range"}>
+        <div className="rack-letter">
+          <FormGroup
+            className={this.props.className}
+            inline={true}
+            label="Row Letter Range   "
+          >
+            <Field
+              field="letter_start"
+              placeholder="start"
+              type="text"
+              value={this.state.values.letter_start}
+              onChange={this.props.handleChange}
+            />
+          </FormGroup>
+          <p className="dash">to</p>
+
+          <FormGroup className={this.props.className}>
             <Field
               field="letter_end"
               type="text"
+              placeholder="end"
+              value={this.props.values.letter_end}
               onChange={this.props.handleChange}
             />
           </FormGroup>
-        ) : null}
-        <FormGroup className={this.props.className} label="Rack Number">
-          <Field
-            field="num_start"
-            type="number"
-            onChange={this.props.handleChange}
-          />
-        </FormGroup>
+        </div>
+        <div className="rack-letter">
+          <FormGroup
+            className={this.props.className}
+            inline={true}
+            label="Rack Number Range"
+          >
+            <Field
+              field="num_start"
+              type="text"
+              placeholder="start"
+              value={this.props.values.num_start}
+              onChange={this.props.handleChange}
+            />
+          </FormGroup>
+          <p className="dash">to</p>
 
-        {this.props.range ? (
-          <FormGroup className={this.props.className} label="Rack Number (end)">
+          <FormGroup className={this.props.className}>
             <Field
               field="num_end"
-              type="number"
+              type="text"
+              placeholder="end"
+              value={this.props.values.num_end}
               onChange={this.props.handleChange}
             />
           </FormGroup>
-        ) : null}
+        </div>
       </div>
     );
   }

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -199,7 +199,7 @@ export function isAssetObject(obj: any): obj is AssetObject {
   return obj && obj.model;
 }
 export function isRackRangeFields(obj: any): obj is RackRangeFields {
-  return obj && obj.letter_start;
+  return obj && (obj.letter_start || obj.letter_start === "");
 }
 export function isUserObject(obj: any): obj is UserInfoObject {
   return obj && obj.username;

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -48,8 +48,8 @@ export interface RackRangeFields {
   datacenter: string;
   letter_start: string;
   letter_end: string;
-  num_start: number;
-  num_end: number;
+  num_start: string;
+  num_end: string;
 }
 
 export interface NetworkConnection {
@@ -68,33 +68,6 @@ export interface PowerConnection {
 export interface ShallowAssetObject extends ParentAssetObject {
   model?: string;
   rack?: string;
-}
-export interface NetworkConnection {
-  source_port: string;
-  destination_hostname: string;
-  destination_port: string;
-}
-export interface NetworkGraph {
-  nodes: { [hostname: string]: string };
-  links: Array<{ [source: string]: string }>;
-}
-export interface PowerConnection {
-  left_right: PowerSide;
-  port_number: string;
-}
-
-export interface PowerPortAvailability {
-  left_suggest: string;
-  left_available: Array<string>;
-  right_suggest: string;
-  right_available: Array<string>;
-}
-export interface RackRangeFields {
-  datacenter: string;
-  letter_start: string;
-  letter_end: string;
-  num_start: number;
-  num_end: number;
 }
 
 export interface SortFilterBody {
@@ -214,7 +187,9 @@ export function isRackObject(obj: any): obj is RackObject {
 export function isAssetObject(obj: any): obj is AssetObject {
   return obj && obj.model;
 }
-
+export function isRackRangeFields(obj: any): obj is RackRangeFields {
+  return obj && obj.letter_start;
+}
 export function isUserObject(obj: any): obj is UserInfoObject {
   return obj && obj.username;
 }


### PR DESCRIPTION
- [x] view all racks is linked to datacenter 
- [x] create and delete racks is linked to datacenter 
note: decided to NOT show all racks upon clicking to the rack tab, since this is really slow if there are a lot of racks -> that would be an unbounded request

NEW:

- [x] logic for rendering racks on delete/clearing racks between different datacenters
- [x] form redesign

- [x] FIXED : when I add a datacenter, then go to racks page to add racks to that datacenter, the newly created datacenter does NOT show up in the dropdown on racks page until after I refresh the page
- [x] FIXED: when I select a datacenter on racks page, click view all, and then change the datacenter selection, the racks displayed do not clear. I think they should clear?
- [ ] tracking, but lower priority: request to create racks (after submit) is quite slow. can we add a loading spinner?