### PR TITLE
Power fixes

### DIFF
--- a/src/components/elementView/detailedView/assetView/assetView.tsx
+++ b/src/components/elementView/detailedView/assetView/assetView.tsx
@@ -30,6 +30,7 @@ import "./assetView.scss";
 import NetworkGraph from "./graph";
 import PowerView from "../../powerView/powerView";
 import { ALL_DATACENTERS } from "../../elementTabContainer";
+import { IconNames } from "@blueprintjs/icons";
 
 export interface AssetViewProps {
   token: string;
@@ -262,7 +263,10 @@ export class AssetView extends React.PureComponent<
               />
             </div>
           ) : (
-            <Callout title="No network ports" intent={Intent.PRIMARY}></Callout>
+            <Callout
+              title="No network ports"
+              icon={IconNames.INFO_SIGN}
+            ></Callout>
           )}
         </div>
 

--- a/src/components/elementView/detailedView/assetView/assetView.tsx
+++ b/src/components/elementView/detailedView/assetView/assetView.tsx
@@ -64,7 +64,7 @@ interface AssetViewState {
 export class AssetView extends React.PureComponent<
   RouteComponentProps & AssetViewProps,
   AssetViewState
-  > {
+> {
   public state: AssetViewState = {
     asset: {} as AssetObject,
     isFormOpen: false,
@@ -214,26 +214,26 @@ export class AssetView extends React.PureComponent<
           <h3>Network Connections</h3>
 
           {this.state.asset.model &&
-            this.state.asset.model.network_ports &&
-            this.state.asset.model.network_ports.length !== 0 ? (
-              <div className="network-connections">
-                <table className="bp3-html-table bp3-html-table-bordered bp3-html-table-striped">
-                  <tr>
-                    <th>Network Port</th>
-                    <th>Mac Address</th>
-                    <th>Destination Asset</th>
-                    <th>Destination Port</th>
-                  </tr>
-                  <tbody>
-                    {this.state.asset.model.network_ports.map((port: string) => {
-                      var connection = this.getNetworkConnectionForPort(port);
-                      return (
-                        <tr>
-                          {" "}
-                          <td>{port}</td>
-                          <td>{this.state.asset.mac_addresses[port]}</td>{" "}
-                          {connection
-                            ? [
+          this.state.asset.model.network_ports &&
+          this.state.asset.model.network_ports.length !== 0 ? (
+            <div className="network-connections">
+              <table className="bp3-html-table bp3-html-table-bordered bp3-html-table-striped">
+                <tr>
+                  <th>Network Port</th>
+                  <th>Mac Address</th>
+                  <th>Destination Asset</th>
+                  <th>Destination Port</th>
+                </tr>
+                <tbody>
+                  {this.state.asset.model.network_ports.map((port: string) => {
+                    var connection = this.getNetworkConnectionForPort(port);
+                    return (
+                      <tr>
+                        {" "}
+                        <td>{port}</td>
+                        <td>{this.state.asset.mac_addresses[port]}</td>{" "}
+                        {connection
+                          ? [
                               <td
                                 className="asset-link"
                                 onClick={(e: any) => {
@@ -249,27 +249,24 @@ export class AssetView extends React.PureComponent<
                               </td>,
                               <td>{connection.destination_port}</td>
                             ]
-                            : [<td></td>, <td></td>]}
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
+                          : [<td></td>, <td></td>]}
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
 
-                <NetworkGraph
-                  networkGraph={this.state.asset.network_graph}
-                  onClickNode={this.redirectToAsset}
-                />
-              </div>
-            ) : (
-              <Callout title="No network ports" intent={Intent.PRIMARY}></Callout>
-            )}
+              <NetworkGraph
+                networkGraph={this.state.asset.network_graph}
+                onClickNode={this.redirectToAsset}
+              />
+            </div>
+          ) : (
+            <Callout title="No network ports" intent={Intent.PRIMARY}></Callout>
+          )}
         </div>
 
-        {Object.keys(this.state.asset).length !== 0 &&
-          Object.keys(this.state.asset.power_connections).length > 0
-          ? this.renderPower()
-          : null}
+        {Object.keys(this.state.asset).length !== 0 ? this.renderPower() : null}
       </div>
     );
   }
@@ -315,7 +312,6 @@ export class AssetView extends React.PureComponent<
   private handleDeleteCancel = () => this.setState({ isDeleteOpen: false });
   private handleDeleteOpen = () => this.setState({ isDeleteOpen: true });
   private handleDelete = () => {
-
     deleteAsset(this.state.asset!, getHeaders(this.props.token))
       .then(res => {
         this.setState({ isDeleteOpen: false });

--- a/src/components/elementView/elementTable.tsx
+++ b/src/components/elementView/elementTable.tsx
@@ -1112,7 +1112,8 @@ class ElementTable extends React.Component<
                                   }}
                                 />
                               ) : null}
-                              {isAssetObject(item) ? (
+                              {isAssetObject(item) &&
+                              item.rack.is_network_controlled ? (
                                 <AnchorButton
                                   className="button-table"
                                   intent="warning"

--- a/src/components/elementView/powerView/powerView.scss
+++ b/src/components/elementView/powerView/powerView.scss
@@ -1,18 +1,18 @@
 .row-power {
-    display: flex;
-    white-space: pre-line;
+  display: flex;
+  white-space: pre-line;
 }
-  
+
 .column-power {
-    text-align: center;
-    flex: 25%;
+  text-align: center;
+  flex: 25%;
 }
 
 .power-dialog {
-    width: 60%;
+  width: 60%;
 }
 
 .power-close {
-    flex: 50%;
-    text-align: center;
+  flex: 50%;
+  text-align: left;
 }

--- a/src/components/elementView/powerView/powerView.scss
+++ b/src/components/elementView/powerView/powerView.scss
@@ -9,7 +9,7 @@
 }
 
 .power-dialog {
-  width: 60%;
+  width: fit-content;
 }
 
 .power-close {

--- a/src/components/elementView/powerView/powerView.tsx
+++ b/src/components/elementView/powerView/powerView.tsx
@@ -17,6 +17,7 @@ import { RouteComponentProps, withRouter } from "react-router";
 import { connect } from "react-redux";
 import { AssetObject, getHeaders } from "../../../utils/utils";
 import "./powerView.scss";
+import { IconNames } from "@blueprintjs/icons";
 
 interface PowerViewProps {
   token: string;
@@ -159,8 +160,8 @@ export class PowerView extends React.PureComponent<
             <div className="propsview">
               <h3>Power Connections</h3>
               <Callout
-                title="No power connections"
-                intent={Intent.PRIMARY}
+                title="No power ports"
+                icon={IconNames.INFO_SIGN}
               ></Callout>
               {this.props.callback === undefined ? null : (
                 <AnchorButton
@@ -185,7 +186,7 @@ export class PowerView extends React.PureComponent<
               <div className="network-connections">
                 <table className="bp3-html-table bp3-html-table-bordered bp3-html-table-striped">
                   <tr>
-                    <th>Asset Port Number</th>
+                    <th>Power Port Number</th>
                     <th>PDU Port Number</th>
                     <th>Power Status</th>
                   </tr>

--- a/src/components/elementView/powerView/powerView.tsx
+++ b/src/components/elementView/powerView/powerView.tsx
@@ -1,15 +1,13 @@
 import {
-    Classes,
-    AnchorButton,
-    Alert,
-    Toaster,
-    IToastProps,
-    Position,
-    Intent,
-    Card,
-    Elevation,
-    Spinner,
-    Divider
+  Classes,
+  AnchorButton,
+  Alert,
+  Toaster,
+  IToastProps,
+  Position,
+  Intent,
+  Spinner,
+  Callout
 } from "@blueprintjs/core";
 import "@blueprintjs/core/lib/css/blueprint.css";
 import axios from "axios";
@@ -21,254 +19,345 @@ import { AssetObject, getHeaders } from "../../../utils/utils";
 import "./powerView.scss";
 
 interface PowerViewProps {
-    token: string;
-    callback?: Function;
-    asset?: AssetObject;
-    shouldUpdate: boolean;
-    updated: Function;
-    isAdmin: boolean
+  token: string;
+  callback?: Function;
+  asset?: AssetObject;
+  shouldUpdate: boolean;
+  updated: Function;
+  isAdmin: boolean;
 }
 
 interface PowerViewState {
-    powerConnections: any;
-    powerStatus: any;
-    statusLoaded: boolean;
-    alertOpen: boolean;
-    confirmationMessage: string;
-    username?: string
+  powerConnections: any;
+  powerStatus: any;
+  statusLoaded: boolean;
+  alertOpen: boolean;
+  confirmationMessage: string;
+  username?: string;
 }
 
 export class PowerView extends React.PureComponent<
-    RouteComponentProps & PowerViewProps,
-    PowerViewState
-    > {
+  RouteComponentProps & PowerViewProps,
+  PowerViewState
+> {
+  //TOASTS
+  private toaster: Toaster = {} as Toaster;
+  private addToast = (toast: IToastProps) => {
+    toast.timeout = 5000;
+    this.toaster.show(toast);
+  };
+  private addSuccessToast = (message: string) => {
+    this.addToast({ message: message, intent: Intent.PRIMARY });
+  };
+  private addErrorToast = (message: string) => {
+    this.addToast({ message: message, intent: Intent.DANGER });
+  };
 
-    //TOASTS
-    private toaster: Toaster = {} as Toaster;
-    private addToast = (toast: IToastProps) => {
-        toast.timeout = 5000;
-        this.toaster.show(toast);
-    };
-    private addSuccessToast = (message: string) => {
-        this.addToast({ message: message, intent: Intent.PRIMARY });
-    };
-    private addErrorToast = (message: string) => {
-        this.addToast({ message: message, intent: Intent.DANGER });
-    };
+  private refHandlers = {
+    toaster: (ref: Toaster) => (this.toaster = ref)
+  };
 
-    private refHandlers = {
-        toaster: (ref: Toaster) => (this.toaster = ref)
-    };
+  public state: PowerViewState = {
+    powerConnections: undefined,
+    powerStatus: undefined,
+    statusLoaded: false,
+    alertOpen: false,
+    confirmationMessage: ""
+  };
 
-    public state: PowerViewState = {
-        powerConnections: undefined,
-        powerStatus: undefined,
-        statusLoaded: false,
-        alertOpen: false,
-        confirmationMessage: ""
-    }
+  componentDidMount() {
+    axios
+      .get(
+        API_ROOT + "api/power/get-state/" + this.props.asset!.id,
+        getHeaders(this.props.token)
+      )
+      .then(res => {
+        this.setState({
+          powerConnections: res.data.power_connections,
+          powerStatus: res.data.power_status,
+          statusLoaded: true
+        });
+      })
+      .catch(err => {
+        this.addErrorToast(err.response.data.failure_message);
+        this.setState({
+          statusLoaded: true
+        });
+      });
+    this.getUsername(this.props.token);
+  }
 
-    componentDidMount() {
-        axios.get(API_ROOT + "api/power/get-state/" + this.props.asset!.id, getHeaders(this.props.token))
-            .then(res => {
-                this.setState({
-                    powerConnections: res.data.power_connections,
-                    powerStatus: res.data.power_status,
-                    statusLoaded: true
-                })
-            }).catch(err => {
-                alert(err)
-            })
-        this.getUsername(this.props.token)
-    }
-
-    componentDidUpdate() {
-        console.log("componentDIDUPDST")
-        if (this.props.shouldUpdate) {
-            console.log("here")
-            axios.get(API_ROOT + "api/power/get-state/" + this.props.asset!.id, getHeaders(this.props.token))
-                .then(res => {
-                    this.setState({
-                        powerConnections: res.data.power_connections,
-                        powerStatus: res.data.power_status,
-                        statusLoaded: true
-                    })
-                }).catch(err => {
-                    alert(err)
-                })
-        }
-        this.props.updated()
-    }
-
-    render() {
-
-        return (
-            <div className={Classes.DARK}>
-                {this.state.statusLoaded ?
-                    (this.state.powerConnections === undefined || Object.keys(this.state.powerConnections).length === 0 ?
-                        <h4>No power connections</h4> :
-                        Object.keys(this.state.powerConnections).map((port: string) => {
-                            return (
-                                <Card elevation={Elevation.TWO}>
-                                    <div key={port} className={"row-power"}>
-                                        <h3 className={"column-power"}>Asset Power Port: {port}</h3>
-                                        <Divider />
-                                        <h3 className={"column-power"}>
-                                            PDU Port: {Object.keys(this.state.powerConnections[port]).map((field: string) => {
-                                                return (
-                                                    this.state.powerConnections[port][field]
-                                                )
-                                            })}
-                                        </h3>
-                                        <Divider />
-                                        <h3 className={"column-power"}>{this.state.powerStatus[port]}</h3>
-                                    </div>
-                                </Card>
-                            )
-                        })) :
-                    <Spinner />
-                }
-                <div className={"row-power"}>
-                    {this.props.asset!.rack.is_network_controlled && this.state.powerStatus &&
-                        (this.state.username === this.props.asset!.owner || this.props.isAdmin) ? <AnchorButton
-                            className={"power-close"}
-                            intent={this.state.powerStatus[Object.keys(this.state.powerStatus)[0]] === "OFF" ? "primary" : "danger"}
-                            minimal
-                            text={this.state.powerStatus[Object.keys(this.state.powerStatus)[0]] === "OFF" ?
-                                "Turn on" : "Turn off"
-                            }
-                            icon="power"
-                            onClick={this.state.powerStatus[Object.keys(this.state.powerStatus)[0]] === "OFF" ?
-                                () => {
-                                    this.setState({
-                                        statusLoaded: !this.state.statusLoaded
-                                    })
-                                    axios.post(
-                                        API_ROOT + "api/power/mask-on",
-                                        { id: this.props.asset!.id },
-                                        getHeaders(this.props.token)
-                                    ).then(res => {
-                                        this.setState({
-                                            alertOpen: true,
-                                            confirmationMessage: res.data.success_message
-                                        })
-                                        this.componentDidMount()
-                                    }).catch(err => {
-                                        alert(err)
-                                    })
-                                } :
-                                () => {
-                                    this.setState({
-                                        statusLoaded: !this.state.statusLoaded
-                                    })
-                                    axios.post(
-                                        API_ROOT + "api/power/mask-off",
-                                        { id: this.props.asset!.id },
-                                        getHeaders(this.props.token)
-                                    ).then(res => {
-                                        this.setState({
-                                            alertOpen: true,
-                                            confirmationMessage: res.data.success_message
-                                        })
-                                        this.componentDidMount()
-                                    }).catch(err => {
-                                        alert(err)
-                                    })
-                                }
-                            }
-                        /> : null}
-                    {this.props.asset!.rack.is_network_controlled && this.state.powerStatus &&
-                        (this.state.username === this.props.asset!.owner || this.props.isAdmin) ? <AnchorButton
-                            className={"power-close"}
-                            minimal
-                            intent="warning"
-                            text={"Cycle Power"}
-                            onClick={() => {
-                                this.setState({
-                                    statusLoaded: !this.state.statusLoaded
-                                })
-                                axios.post(
-                                    API_ROOT + "api/power/cycle",
-                                    { id: this.props.asset!.id },
-                                    getHeaders(this.props.token)
-                                ).then(res => {
-                                    this.setState({
-                                        alertOpen: true,
-                                        confirmationMessage: res.data.success_message
-                                    })
-                                    this.componentDidMount()
-                                }).catch(err => {
-                                    alert(err)
-                                })
-                            }}
-                        /> : null}
-                    <Divider />
-                    {this.props.callback === undefined ? null :
-                        <AnchorButton
-                            className={"power-close"}
-                            intent="danger"
-                            minimal
-                            text="Close"
-                            onClick={() => {
-                                this.setState({
-                                    powerConnections: undefined,
-                                    powerStatus: undefined,
-                                    statusLoaded: false
-                                })
-                                this.props.callback!()
-                            }}
-                        />}
-                </div>
-                <Alert
-                    className={Classes.DARK}
-                    confirmButtonText="Okay"
-                    isOpen={this.state.alertOpen}
-                    onConfirm={() => {
-                        this.setState({
-                            alertOpen: false
-                        })
-                    }}
-                    onClose={() => {
-                        this.setState({
-                            alertOpen: false
-                        })
-                    }}
-                >
-                    <p>{this.state.confirmationMessage}</p>
-                </Alert>
-                <Toaster
-                    autoFocus={false}
-                    canEscapeKeyClear={true}
-                    position={Position.TOP}
-                    ref={this.refHandlers.toaster}
-                />
-            </div >
+  componentDidUpdate() {
+    console.log("componentDIDUPDST");
+    if (this.props.shouldUpdate) {
+      console.log("here");
+      axios
+        .get(
+          API_ROOT + "api/power/get-state/" + this.props.asset!.id,
+          getHeaders(this.props.token)
         )
+        .then(res => {
+          this.setState({
+            powerConnections: res.data.power_connections,
+            powerStatus: res.data.power_status,
+            statusLoaded: true
+          });
+        })
+        .catch(err => {
+          this.addErrorToast(err.response.data.failure_message);
+          this.setState({
+            statusLoaded: true
+          });
+        });
     }
+    this.props.updated();
+  }
 
-    private getUsername(token: string) {
-        const headers = {
-            headers: {
-                Authorization: "Token " + token
-            }
-        };
-        axios
-            .get(API_ROOT + "api/users/who-am-i", headers)
-            .then(res => {
-                this.setState({ username: res.data.username })
-            })
-            .catch(err => {
-                console.log(err);
+  render() {
+    return (
+      <div className={Classes.DARK}>
+        {this.state.statusLoaded ? (
+          !(
+            this.props.asset &&
+            Object.keys(this.props.asset.power_connections).length > 0
+          ) ? (
+            <div className="propsview">
+              <h3>Power Connections</h3>
+              <Callout
+                title="No power connections"
+                intent={Intent.PRIMARY}
+              ></Callout>
+              {this.props.callback === undefined ? null : (
+                <AnchorButton
+                  className={"power-close"}
+                  intent="danger"
+                  minimal
+                  text="Close"
+                  onClick={() => {
+                    this.setState({
+                      powerConnections: undefined,
+                      powerStatus: undefined,
+                      statusLoaded: false
+                    });
+                    this.props.callback!();
+                  }}
+                />
+              )}
+            </div>
+          ) : (
+            <div className="propsview">
+              <h3>Power Connections</h3>
+              <div className="network-connections">
+                <table className="bp3-html-table bp3-html-table-bordered bp3-html-table-striped">
+                  <tr>
+                    <th>Asset Port Number</th>
+                    <th>PDU Port Number</th>
+                    <th>Power Status</th>
+                  </tr>
+                  <tbody>
+                    {Object.keys(this.props.asset.power_connections).map(
+                      (port: string) => {
+                        return (
+                          <tr>
+                            {" "}
+                            <td>{port}</td>
+                            <td>
+                              {
+                                this.props.asset!.power_connections[port]
+                                  .port_number
+                              }
+                              {
+                                this.props.asset!.power_connections[port]
+                                  .left_right
+                              }
+                            </td>
+                            {this.props.asset!.rack.is_network_controlled ? (
+                              this.state.powerStatus ? (
+                                <td>{this.state.powerStatus[port]}</td>
+                              ) : (
+                                <td>Unable to contact PDU controller</td>
+                              )
+                            ) : (
+                              <td>PDU not network controlled</td>
+                            )}
+                          </tr>
+                        );
+                      }
+                    )}
+                  </tbody>
+                </table>
+              </div>
+              {this.props.asset!.rack.is_network_controlled &&
+              Object.keys(this.props.asset!.power_connections).length > 0 &&
+              this.state.powerStatus ? (
+                <AnchorButton
+                  className={"power-close"}
+                  intent={
+                    this.state.powerStatus[
+                      Object.keys(this.state.powerStatus)[0]
+                    ] === "OFF"
+                      ? "primary"
+                      : "danger"
+                  }
+                  minimal
+                  text={
+                    this.state.powerStatus[
+                      Object.keys(this.state.powerStatus)[0]
+                    ] === "OFF"
+                      ? "Turn on"
+                      : "Turn off"
+                  }
+                  icon="power"
+                  onClick={
+                    this.state.powerStatus[
+                      Object.keys(this.state.powerStatus)[0]
+                    ] === "OFF"
+                      ? () => {
+                          this.setState({
+                            statusLoaded: !this.state.statusLoaded
+                          });
+                          axios
+                            .post(
+                              API_ROOT + "api/power/mask-on",
+                              { id: this.props.asset!.id },
+                              getHeaders(this.props.token)
+                            )
+                            .then(res => {
+                              this.setState({
+                                alertOpen: true,
+                                confirmationMessage: res.data.success_message
+                              });
+                              this.componentDidMount();
+                            })
+                            .catch(err => {
+                              alert(err);
+                            });
+                        }
+                      : () => {
+                          this.setState({
+                            statusLoaded: !this.state.statusLoaded
+                          });
+                          axios
+                            .post(
+                              API_ROOT + "api/power/mask-off",
+                              { id: this.props.asset!.id },
+                              getHeaders(this.props.token)
+                            )
+                            .then(res => {
+                              this.setState({
+                                alertOpen: true,
+                                confirmationMessage: res.data.success_message
+                              });
+                              this.componentDidMount();
+                            })
+                            .catch(err => {
+                              alert(err);
+                            });
+                        }
+                  }
+                />
+              ) : null}
+              {this.props.asset!.rack.is_network_controlled &&
+              Object.keys(this.props.asset!.power_connections).length > 0 &&
+              this.state.powerStatus ? (
+                <AnchorButton
+                  className={"power-close"}
+                  minimal
+                  intent="warning"
+                  text={"Cycle Power"}
+                  onClick={() => {
+                    this.setState({
+                      statusLoaded: !this.state.statusLoaded
+                    });
+                    axios
+                      .post(
+                        API_ROOT + "api/power/cycle",
+                        { id: this.props.asset!.id },
+                        getHeaders(this.props.token)
+                      )
+                      .then(res => {
+                        this.setState({
+                          alertOpen: true,
+                          confirmationMessage: res.data.success_message
+                        });
+                        this.componentDidMount();
+                      })
+                      .catch(err => {
+                        alert(err);
+                      });
+                  }}
+                />
+              ) : null}
+              {this.props.callback === undefined ? null : (
+                <AnchorButton
+                  className={"power-close"}
+                  intent="danger"
+                  minimal
+                  text="Close"
+                  onClick={() => {
+                    this.setState({
+                      powerConnections: undefined,
+                      powerStatus: undefined,
+                      statusLoaded: false
+                    });
+                    this.props.callback!();
+                  }}
+                />
+              )}
+            </div>
+          )
+        ) : (
+          <Spinner />
+        )}
+        <Alert
+          className={Classes.DARK}
+          confirmButtonText="Okay"
+          isOpen={this.state.alertOpen}
+          onConfirm={() => {
+            this.setState({
+              alertOpen: false
             });
-    }
+          }}
+          onClose={() => {
+            this.setState({
+              alertOpen: false
+            });
+          }}
+        >
+          <p>{this.state.confirmationMessage}</p>
+        </Alert>
+        <Toaster
+          autoFocus={false}
+          canEscapeKeyClear={true}
+          position={Position.TOP}
+          ref={this.refHandlers.toaster}
+        />
+      </div>
+    );
+  }
 
+  private getUsername(token: string) {
+    const headers = {
+      headers: {
+        Authorization: "Token " + token
+      }
+    };
+    axios
+      .get(API_ROOT + "api/users/who-am-i", headers)
+      .then(res => {
+        this.setState({ username: res.data.username });
+      })
+      .catch(err => {
+        console.log(err);
+      });
+  }
 }
 
 const mapStatetoProps = (state: any) => {
-    return {
-        token: state.token,
-        isAdmin: state.admin
-    };
+  return {
+    token: state.token,
+    isAdmin: state.admin
+  };
 };
 
 export default withRouter(connect(mapStatetoProps)(PowerView));

--- a/src/components/elementView/powerView/powerView.tsx
+++ b/src/components/elementView/powerView/powerView.tsx
@@ -113,13 +113,48 @@ export class PowerView extends React.PureComponent<
     this.props.updated();
   }
 
+  getPowerPortRows() {
+    const rows = [];
+    if (this.props.asset) {
+      for (
+        let i = 1;
+        i < ((this.props.asset.model.num_power_ports as unknown) as number) + 1;
+        i++
+      ) {
+        rows.push(
+          <tr>
+            <td>{i}</td>
+            {this.props.asset!.power_connections[i] ? (
+              <td>
+                {this.props.asset!.power_connections[i].port_number}
+                {this.props.asset!.power_connections[i].left_right}
+              </td>
+            ) : (
+              <td></td>
+            )}
+            {this.props.asset!.rack.is_network_controlled ? (
+              this.state.powerStatus ? (
+                <td>{this.state.powerStatus[i]}</td>
+              ) : (
+                <td>Unable to contact PDU controller</td>
+              )
+            ) : (
+              <td>PDU not network controlled</td>
+            )}
+          </tr>
+        );
+      }
+    }
+    return rows;
+  }
+
   render() {
     return (
       <div className={Classes.DARK}>
         {this.state.statusLoaded ? (
           !(
             this.props.asset &&
-            Object.keys(this.props.asset.power_connections).length > 0
+            ((this.props.asset.model.num_power_ports as unknown) as number) > 0
           ) ? (
             <div className="propsview">
               <h3>Power Connections</h3>
@@ -154,37 +189,7 @@ export class PowerView extends React.PureComponent<
                     <th>PDU Port Number</th>
                     <th>Power Status</th>
                   </tr>
-                  <tbody>
-                    {Object.keys(this.props.asset.power_connections).map(
-                      (port: string) => {
-                        return (
-                          <tr>
-                            {" "}
-                            <td>{port}</td>
-                            <td>
-                              {
-                                this.props.asset!.power_connections[port]
-                                  .port_number
-                              }
-                              {
-                                this.props.asset!.power_connections[port]
-                                  .left_right
-                              }
-                            </td>
-                            {this.props.asset!.rack.is_network_controlled ? (
-                              this.state.powerStatus ? (
-                                <td>{this.state.powerStatus[port]}</td>
-                              ) : (
-                                <td>Unable to contact PDU controller</td>
-                              )
-                            ) : (
-                              <td>PDU not network controlled</td>
-                            )}
-                          </tr>
-                        );
-                      }
-                    )}
-                  </tbody>
+                  <tbody>{this.getPowerPortRows()}</tbody>
                 </table>
               </div>
               {this.props.asset!.rack.is_network_controlled &&


### PR DESCRIPTION
- if no power ports, now shows "no power ports"
- if power ports, but none are plugged in, still currently shows "no power ports," I would take the time to fix this but I think there are more pressing issues
- if power ports and they are plugged in but not on a pdu controlled rack, displays them in the table, but the on/off state column just says "not PDU controlled"
- if power ports, and they are plugged in, and they are on an rtp1 rack, displays power data too
- power connectivity issues now shown as toasts
- other front end/aesthetic updates