### PR TITLE
Form prepopulation bug fixes

### DIFF
--- a/src/forms/userForm.tsx
+++ b/src/forms/userForm.tsx
@@ -27,7 +27,6 @@ import { FormTypes } from "./formUtils";
 import { API_ROOT } from "../utils/api-config";
 import { modifyUser } from "../components/elementView/elementUtils";
 
-//TO DO : add validation of types!!!
 var console: any = {};
 console.log = function() {};
 
@@ -35,7 +34,6 @@ export interface UserFormProps {
   userId: string;
   token: string;
   type?: FormTypes;
-  // submitForm(model: UserPermissionsObject, headers: any): Promise<any> | void;
   submitForm: Function;
 }
 interface UserFormState {
@@ -396,11 +394,7 @@ class UserForm extends React.Component<UserFormProps, UserFormState> {
           initialValues: res.data,
           permissions: res.data
         });
-        if (
-          res.data.asset_management
-          // res.data.datacenter_permissions.length ===
-          // this.state.datacenters.length
-        ) {
+        if (res.data.asset_management) {
           this.setState({
             datacenter_selection: "Global"
           });

--- a/src/forms/userForm.tsx
+++ b/src/forms/userForm.tsx
@@ -28,8 +28,8 @@ import { API_ROOT } from "../utils/api-config";
 import { modifyUser } from "../components/elementView/elementUtils";
 
 //TO DO : add validation of types!!!
-// var console: any = {};
-// console.log = function() {};
+var console: any = {};
+console.log = function() {};
 
 export interface UserFormProps {
   userId: string;
@@ -397,8 +397,9 @@ class UserForm extends React.Component<UserFormProps, UserFormState> {
           permissions: res.data
         });
         if (
-          res.data.datacenter_permissions.length ===
-          this.state.datacenters.length
+          res.data.asset_management
+          // res.data.datacenter_permissions.length ===
+          // this.state.datacenters.length
         ) {
           this.setState({
             datacenter_selection: "Global"


### PR DESCRIPTION
- [x] Global asset management form prepopulation now works as expected

- [x] Giving per datacenter permissions no longer accidentally sends asset_management (global permission) as true

- [x] Unchecking admin does not leave all other boxes still checked unless they were checked before admin was checked