### PR TITLE
Fix conflicts that happen after execute

### DIFF
--- a/rackcity/views/change_plan_views.py
+++ b/rackcity/views/change_plan_views.py
@@ -461,6 +461,10 @@ def change_plan_execute(request, id):
                 },
                 status=HTTPStatus.BAD_REQUEST,
             )
+
+    change_plan.execution_time = datetime.now()
+    change_plan.save()
+
     num_created = 0
     num_modified = 0
     num_decommissioned = 0
@@ -505,9 +509,6 @@ def change_plan_execute(request, id):
                 Action.DECOMMISSION,
                 change_plan=change_plan,
             )
-
-    change_plan.execution_time = datetime.now()
-    change_plan.save()
 
     log_execute_change_plan(
         request.user,


### PR DESCRIPTION
Need to mark change plan as executed before executing updates on related assets because they will be marked as conflicts UNLESS the change plan is executed