### PR TITLE
Refactor - Clean up & reorganize backend utils

### DIFF
--- a/rackcity/models/network_port.py
+++ b/rackcity/models/network_port.py
@@ -14,7 +14,7 @@ def format_mac_address(mac_address):
     mac_address = mac_address.replace(",", ":")
     mac_address = mac_address.replace(";", ":")
     # if contains no delimiters:
-    if (not mac_address.__contains__(":")):
+    if not (mac_address.__contains__(":")):
         mac_address = ':'.join(
             a+b for a, b in zip(mac_address[::2], mac_address[1::2]))
     return mac_address
@@ -37,12 +37,13 @@ class AbstractNetworkPort(models.Model):
         null=True,
         blank=True,
     )
+
     def create_network_connection(self, destination_port):
         if (
             destination_port.connected_port
             and destination_port.connected_port != self
         ):
-            from rackcity.views.rackcity_utils import NetworkConnectionException
+            from rackcity.utils.exceptions import NetworkConnectionException
 
             raise NetworkConnectionException(
                 "Destination port '"

--- a/rackcity/utils/asset_utils.py
+++ b/rackcity/utils/asset_utils.py
@@ -1,0 +1,387 @@
+from django.core.exceptions import ObjectDoesNotExist
+from rackcity.models import (
+    Asset,
+    AssetCP,
+    NetworkPort,
+    NetworkPortCP,
+    PowerPort,
+    PowerPortCP,
+    PDUPort,
+    PDUPortCP,
+)
+from rackcity.models.asset import get_assets_for_cp
+from rackcity.utils.exceptions import (
+    MacAddressException,
+    NetworkConnectionException,
+    PowerConnectionException,
+)
+
+
+def save_network_connections(asset_data, asset_id, change_plan=None):
+    if "network_connections" not in asset_data or not asset_data["network_connections"]:
+        return
+    network_connections = asset_data["network_connections"]
+    failure_message = ""
+    for network_connection in network_connections:
+        port_name = network_connection["source_port"]
+        try:
+            if change_plan:
+                network_port = NetworkPortCP.objects.get(
+                    asset=asset_id, port_name=port_name, change_plan=change_plan
+                )
+            else:
+                network_port = NetworkPort.objects.get(
+                    asset=asset_id, port_name=port_name
+                )
+        except ObjectDoesNotExist:
+            failure_message += "Port name '" + port_name + "' is not valid. "
+        else:
+            if (
+                not network_connection["destination_hostname"]
+                and not network_connection["destination_port"]
+            ):
+
+                if change_plan:
+                    # need to add deleted connection's asset to asset change plan
+                    asset_cp = AssetCP.objects.get(id=asset_id)
+                    if asset_cp.related_asset_id:
+                        asset_live = Asset.objects.get(id=asset_cp.related_asset_id)
+                        network_port_live = NetworkPort.objects.get(
+                            asset=asset_live, port_name=port_name
+                        )
+                        if network_port_live.connected_port:
+                            destination_port_live = NetworkPort.objects.filter(
+                                id=network_port_live.connected_port_id
+                            )[0]
+                            destination_asset_live = Asset.objects.get(
+                                id=destination_port_live.asset_id
+                            )
+                            destination_asset_cp = AssetCP(
+                                related_asset=destination_asset_live,
+                                change_plan=change_plan,
+                            )
+                        # add destination asset to AssetCPTable
+                        for field in destination_asset_live._meta.fields:
+                            if field.name != "id" and field.name != "assetid_ptr":
+                                setattr(
+                                    destination_asset_cp,
+                                    field.name,
+                                    getattr(destination_asset_live, field.name),
+                                )
+
+                        destination_asset_cp.save()
+
+                        # Destination asset has been added to AssetCP, but its
+                        # network ports are empty (no connections/mac
+                        # addresses) get the network ports from the live asset
+                        dest_network_ports_live = NetworkPort.objects.filter(
+                            asset=destination_asset_live
+                        )
+                        for dest_network_port_live in dest_network_ports_live:
+                            # for each port, copy over mac address values
+                            dest_network_port_cp = NetworkPortCP.objects.get(
+                                asset=destination_asset_cp,
+                                port_name=dest_network_port_live.port_name,
+                            )
+                            dest_network_port_cp.mac_address = (
+                                dest_network_port_live.mac_address
+                            )
+                            # also copy over the connected_port if there 1. is
+                            # a connection and 2. is not the port that is being
+                            # deleted in this PR
+                            if dest_network_port_live.connected_port and not (
+                                dest_network_port_live.connected_port.port_name
+                                == port_name
+                            ):
+                                dest_network_port_cp.connected_port = (
+                                    dest_network_port_live.connected_port
+                                )
+                            dest_network_port_cp.save()
+                        # same dealio with power ports
+                        dest_power_ports_live = PowerPort.objects.filter(
+                            asset=destination_asset_live
+                        )
+                        for dest_power_port_live in dest_power_ports_live:
+                            dest_power_port_cp = PowerPortCP.objects.get(
+                                asset=destination_asset_cp,
+                                port_name=dest_power_port_live.port_name,
+                            )
+                            dest_pdu_live = dest_power_port_live.power_connection
+                            # if the live power port had a pdu connection,
+                            # create/update the PDUs on PDUCP
+                            if dest_pdu_live:
+                                if PDUPortCP.objects.filter(
+                                    rack=dest_pdu_live.rack,
+                                    left_right=dest_pdu_live.left_right,
+                                    port_number=dest_pdu_live.port_number,
+                                    change_plan=change_plan,
+                                ).exists():
+                                    pdu_port = PDUPortCP.objects.filter(
+                                        rack=dest_pdu_live.rack,
+                                        left_right=dest_pdu_live.left_right,
+                                        port_number=dest_pdu_live.port_number,
+                                        change_plan=change_plan,
+                                    )
+                                else:
+                                    pdu_port = PDUPortCP(change_plan=change_plan)
+                                    for field in dest_pdu_live._meta.fields:
+                                        if field.name != "id":
+                                            setattr(
+                                                pdu_port,
+                                                field.name,
+                                                getattr(dest_pdu_live, field.name,),
+                                            )
+                                    pdu_port.save()
+                                dest_power_port_cp.power_connection = pdu_port
+                                dest_power_port_cp.save()
+
+                network_port.delete_network_connection()
+
+                continue
+            if not network_connection["destination_hostname"]:
+                failure_message += (
+                    "Could not create connection on port '"
+                    + port_name
+                    + "' because no destination hostname was provided."
+                )
+                continue
+            if not network_connection["destination_port"]:
+                failure_message += (
+                    "Could not create connection on port '"
+                    + port_name
+                    + "' because no destination port was provided."
+                )
+                continue
+            try:
+                if change_plan:
+                    assets, assets_cp = get_assets_for_cp(change_plan.id)
+                    if assets.filter(
+                        hostname=network_connection["destination_hostname"]
+                    ).exists():
+                        destination_asset = assets.get(
+                            hostname=network_connection["destination_hostname"]
+                        )
+                        asset_cp = AssetCP(
+                            related_asset=destination_asset, change_plan=change_plan
+                        )
+                        # add destination asset to AssetCPTable
+                        for field in destination_asset._meta.fields:
+                            if field.name != "id" and field.name != "assetid_ptr":
+                                setattr(
+                                    asset_cp,
+                                    field.name,
+                                    getattr(destination_asset, field.name),
+                                )
+                        asset_cp.save()
+                        # copy over mac address values, the actual connections
+                        # get made later in the create_network_connections()
+                        # method
+                        dest_network_ports_live = NetworkPort.objects.filter(
+                            asset=destination_asset
+                        )
+                        for dest_network_port_live in dest_network_ports_live:
+                            dest_network_port_cp = NetworkPortCP.objects.get(
+                                asset=asset_cp,
+                                port_name=dest_network_port_live.port_name,
+                            )
+                            dest_network_port_cp.mac_address = (
+                                dest_network_port_live.mac_address
+                            )
+                            dest_network_port_cp.save()
+
+                        # power connection info
+                        dest_power_ports_live = PowerPort.objects.filter(
+                            asset=destination_asset
+                        )
+                        for dest_power_port_live in dest_power_ports_live:
+                            dest_power_port_cp = PowerPortCP.objects.get(
+                                asset=asset_cp,
+                                port_name=dest_power_port_live.port_name,
+                            )
+                            dest_pdu_live = dest_power_port_live.power_connection
+                            if dest_pdu_live:
+                                if PDUPortCP.objects.filter(
+                                    rack=dest_pdu_live.rack,
+                                    left_right=dest_pdu_live.left_right,
+                                    port_number=dest_pdu_live.port_number,
+                                    change_plan=change_plan,
+                                ).exists():
+                                    pdu_port = PDUPortCP.objects.filter(
+                                        rack=dest_pdu_live.rack,
+                                        left_right=dest_pdu_live.left_right,
+                                        port_number=dest_pdu_live.port_number,
+                                        change_plan=change_plan,
+                                    )
+                                else:
+                                    pdu_port = PDUPortCP(change_plan=change_plan)
+                                    for field in dest_pdu_live._meta.fields:
+                                        if field.name != "id":
+                                            setattr(
+                                                pdu_port,
+                                                field.name,
+                                                getattr(dest_pdu_live, field.name,),
+                                            )
+                                    pdu_port.save()
+                                dest_power_port_cp.power_connection = pdu_port
+                                dest_power_port_cp.save()
+                        destination_asset = asset_cp
+
+                    else:
+                        destination_asset = assets_cp.get(
+                            hostname=network_connection["destination_hostname"],
+                            change_plan=change_plan,
+                        )
+                else:
+                    destination_asset = Asset.objects.get(
+                        hostname=network_connection["destination_hostname"]
+                    )
+            except ObjectDoesNotExist:
+                failure_message += (
+                    "Asset with hostname '"
+                    + network_connection["destination_hostname"]
+                    + "' does not exist. "
+                )
+            else:
+                try:
+                    if change_plan:
+                        destination_port = NetworkPortCP.objects.get(
+                            asset=destination_asset,
+                            port_name=network_connection["destination_port"],
+                            change_plan=change_plan,
+                        )
+                    else:
+                        destination_port = NetworkPort.objects.get(
+                            asset=destination_asset,
+                            port_name=network_connection["destination_port"],
+                        )
+                except ObjectDoesNotExist:
+                    failure_message += (
+                        "Destination port '"
+                        + network_connection["destination_hostname"]
+                        + ":"
+                        + network_connection["destination_port"]
+                        + "' does not exist. "
+                    )
+                else:
+                    try:
+                        network_port.create_network_connection(
+                            destination_port=destination_port
+                        )
+                    except Exception as error:
+                        failure_message += (
+                            "Could not save connection for port '"
+                            + port_name
+                            + "'. "
+                            + str(error)
+                        )
+    if failure_message:
+        raise NetworkConnectionException(failure_message)
+
+
+def save_power_connections(asset_data, asset_id, change_plan=None):
+    if "power_connections" not in asset_data or not asset_data["power_connections"]:
+        return
+    power_connection_assignments = asset_data["power_connections"]
+    failure_message = ""
+    for port_name in power_connection_assignments.keys():
+        try:
+            if change_plan:
+                power_port = PowerPortCP.objects.get(
+                    asset=asset_id, port_name=port_name, change_plan=change_plan.id
+                )
+            else:
+                power_port = PowerPort.objects.get(asset=asset_id, port_name=port_name)
+        except ObjectDoesNotExist:
+            failure_message += (
+                "Power port '" + port_name + "' does not exist on this asset. "
+            )
+        else:
+            power_connection_data = power_connection_assignments[port_name]
+            if change_plan:
+                asset = AssetCP.objects.get(id=asset_id)
+            else:
+                asset = Asset.objects.get(id=asset_id)
+            if not power_connection_data:
+                power_port.power_connection = None
+                power_port.save()
+                continue
+            try:
+                pdu_port_master = PDUPort.objects.get(
+                    rack=asset.rack,
+                    left_right=power_connection_data["left_right"],
+                    port_number=power_connection_data["port_number"],
+                )
+                pdu_port = pdu_port_master
+                if change_plan:
+                    if PDUPortCP.objects.filter(
+                        rack=asset.rack,
+                        left_right=power_connection_data["left_right"],
+                        port_number=power_connection_data["port_number"],
+                        change_plan=change_plan,
+                    ).exists():
+                        pdu_port = PDUPortCP.objects.get(
+                            rack=asset.rack,
+                            left_right=power_connection_data["left_right"],
+                            port_number=power_connection_data["port_number"],
+                            change_plan=change_plan,
+                        )
+                    else:
+                        pdu_port = PDUPortCP(change_plan=change_plan)
+                        for field in pdu_port_master._meta.fields:
+                            if field.name != "id":
+                                setattr(
+                                    pdu_port,
+                                    field.name,
+                                    getattr(pdu_port_master, field.name),
+                                )
+                        pdu_port.save()
+
+            except ObjectDoesNotExist:
+                failure_message += (
+                    "PDU port '"
+                    + power_connection_data["left_right"]
+                    + str(power_connection_data["port_number"])
+                    + "' does not exist. "
+                )
+            else:
+                power_port.power_connection = pdu_port
+                try:
+                    power_port.save()
+                except Exception as error:
+                    failure_message += (
+                        "Power connection on port '"
+                        + port_name
+                        + "' of asset '"
+                        + str(asset.asset_number)
+                        + "' was not valid. "
+                    )
+    if failure_message:
+        raise PowerConnectionException(failure_message)
+
+
+def save_mac_addresses(asset_data, asset_id, change_plan=None):
+    if "mac_addresses" not in asset_data or not asset_data["mac_addresses"]:
+        return
+    mac_address_assignments = asset_data["mac_addresses"]
+    failure_message = ""
+    for port_name in mac_address_assignments.keys():
+        try:
+            if change_plan:
+                network_port = NetworkPortCP.objects.get(
+                    asset=asset_id, port_name=port_name, change_plan=change_plan
+                )
+            else:
+                network_port = NetworkPort.objects.get(
+                    asset=asset_id, port_name=port_name
+                )
+        except ObjectDoesNotExist:
+            failure_message += "Port name '" + port_name + "' is not valid. "
+        else:
+            mac_address = mac_address_assignments[port_name]
+            network_port.mac_address = mac_address
+            try:
+                network_port.save()
+            except Exception:
+                failure_message += "Mac address '" + mac_address + "' is not valid. "
+    if failure_message:
+        raise MacAddressException(failure_message)

--- a/rackcity/utils/exceptions.py
+++ b/rackcity/utils/exceptions.py
@@ -1,0 +1,23 @@
+class LocationException(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
+
+
+class ModelModificationException(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
+
+
+class MacAddressException(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
+
+
+class PowerConnectionException(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
+
+
+class NetworkConnectionException(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)

--- a/rackcity/views/asset_views.py
+++ b/rackcity/views/asset_views.py
@@ -1,20 +1,9 @@
-from django.http import JsonResponse
-from rackcity.models import (
-    Asset,
-    AssetCP,
-    DecommissionedAsset,
-    ITModel,
-    Rack,
-    NetworkPort,
-    NetworkPortCP,
-    PowerPort,
-    PowerPortCP,
-    PDUPort,
-    PDUPortCP,
-    Datacenter,
-)
-from rackcity.models.asset import get_assets_for_cp
+from base64 import b64decode
+import csv
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.http import JsonResponse
+from http import HTTPStatus
+from io import StringIO, BytesIO
 from rackcity.api.serializers import (
     AssetSerializer,
     AssetCPSerializer,
@@ -28,14 +17,30 @@ from rackcity.api.serializers import (
     normalize_bulk_asset_data,
     normalize_bulk_network_data,
 )
-from rackcity.utils.log_utils import (
-    log_action,
-    log_bulk_upload,
-    log_bulk_approve,
-    log_delete,
-    log_network_action,
-    Action,
-    ElementType,
+from rackcity.models import (
+    Asset,
+    AssetCP,
+    DecommissionedAsset,
+    ITModel,
+    Rack,
+    NetworkPort,
+    Datacenter,
+)
+from rackcity.models.asset import (
+    get_assets_for_cp,
+    get_next_available_asset_number,
+    validate_asset_number_uniqueness,
+)
+from rackcity.utils.asset_utils import (
+    save_mac_addresses,
+    save_network_connections,
+    save_power_connections,
+)
+from rackcity.utils.change_planner_utils import (
+    get_change_plan,
+    get_many_assets_response_for_cp,
+    get_page_count_response_for_cp,
+    get_cp_already_executed_response,
 )
 from rackcity.utils.errors_utils import (
     Status,
@@ -45,44 +50,41 @@ from rackcity.utils.errors_utils import (
     BulkFailure,
     AuthFailure,
 )
-from rackcity.permissions.permissions import user_has_asset_permission
-from rest_framework.decorators import permission_classes, api_view
-from rest_framework.permissions import IsAuthenticated
-from rest_framework.parsers import JSONParser
-from http import HTTPStatus
-import csv
-from base64 import b64decode
-import re
-from io import StringIO, BytesIO
+from rackcity.utils.exceptions import (
+    LocationException,
+    MacAddressException,
+    PowerConnectionException,
+    NetworkConnectionException,
+)
+from rackcity.utils.log_utils import (
+    log_action,
+    log_bulk_upload,
+    log_bulk_approve,
+    log_delete,
+    log_network_action,
+    Action,
+    ElementType,
+)
 from rackcity.utils.query_utils import (
     get_sort_arguments,
     get_filter_arguments,
     get_page_count_response,
     get_many_response,
 )
-from rackcity.utils.change_planner_utils import (
-    get_many_assets_response_for_cp,
-    get_page_count_response_for_cp,
-    get_cp_already_executed_response,
-)
-from rackcity.views.rackcity_utils import (
+from rackcity.utils.rackcity_utils import (
     validate_asset_location,
     validate_location_modification,
     no_infile_location_conflicts,
     records_are_identical,
-    LocationException,
-    MacAddressException,
-    PowerConnectionException,
-    NetworkConnectionException,
-    get_change_plan
 )
-from rackcity.models.asset import (
-    get_next_available_asset_number,
-    validate_asset_number_uniqueness,
-)
+from rackcity.permissions.permissions import user_has_asset_permission
+import re
+from rest_framework.decorators import permission_classes, api_view
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.parsers import JSONParser
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def asset_many(request):
     """
@@ -90,27 +92,19 @@ def asset_many(request):
     assets are returned. If page is specified as a query parameter, page
     size must also be specified, and a page of assets will be returned.
     """
-    if request.query_params.get('change_plan'):
+    if request.query_params.get("change_plan"):
         (change_plan, response) = get_change_plan(
-            request.query_params.get('change_plan')
+            request.query_params.get("change_plan")
         )
         if response:
             return response
         else:
-            return get_many_assets_response_for_cp(
-                request,
-                change_plan,
-            )
+            return get_many_assets_response_for_cp(request, change_plan,)
     else:
-        return get_many_response(
-            Asset,
-            RecursiveAssetSerializer,
-            "assets",
-            request,
-        )
+        return get_many_response(Asset, RecursiveAssetSerializer, "assets", request,)
 
 
-@api_view(['GET'])
+@api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def asset_detail(request, id):
     """
@@ -120,13 +114,15 @@ def asset_detail(request, id):
     serializer = None
     if request.query_params.get("change_plan"):
         (change_plan, response) = get_change_plan(
-            request.query_params.get("change_plan"))
+            request.query_params.get("change_plan")
+        )
         if response:
             return response
     try:
         if change_plan:
             assets, assets_cp = get_assets_for_cp(
-                change_plan.id, show_decommissioned=True)
+                change_plan.id, show_decommissioned=True
+            )
             # if id of live asset is given on a change plan, just return the corresponding related assetCP
             if assets_cp.filter(related_asset=id).exists():
                 asset = assets_cp.get(related_asset=id)
@@ -146,12 +142,12 @@ def asset_detail(request, id):
         except DecommissionedAsset.DoesNotExist:
             return JsonResponse(
                 {
-                    "failure_message":
-                        Status.ERROR.value +
-                        "Asset" + GenericFailure.DOES_NOT_EXIST.value,
-                    "errors": "No existing asset with id="+str(id)
+                    "failure_message": Status.ERROR.value
+                    + "Asset"
+                    + GenericFailure.DOES_NOT_EXIST.value,
+                    "errors": "No existing asset with id=" + str(id),
                 },
-                status=HTTPStatus.BAD_REQUEST
+                status=HTTPStatus.BAD_REQUEST,
             )
         else:
             serializer = GetDecommissionedAssetSerializer(decommissioned_asset)
@@ -159,26 +155,27 @@ def asset_detail(request, id):
     return JsonResponse(serializer.data, status=HTTPStatus.OK)
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def asset_add(request):
     """
     Add a new asset.
     """
     data = JSONParser().parse(request)
-    if 'id' in data:
+    if "id" in data:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.CREATE_ERROR.value + GenericFailure.INTERNAL.value,
-                "errors": "Don't include 'id' when creating an asset"
+                "failure_message": Status.CREATE_ERROR.value
+                + GenericFailure.INTERNAL.value,
+                "errors": "Don't include 'id' when creating an asset",
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     change_plan = None
     if request.query_params.get("change_plan"):
         (change_plan, response) = get_change_plan(
-            request.query_params.get("change_plan"))
+            request.query_params.get("change_plan")
+        )
         if response:
             return response
         response = get_cp_already_executed_response(change_plan)
@@ -191,111 +188,88 @@ def asset_add(request):
     if not serializer.is_valid(raise_exception=False):
         return JsonResponse(
             {
-                "failure_message":
-                    Status.INVALID_INPUT.value +
-                    parse_serializer_errors(serializer.errors),
-                "errors": str(serializer.errors)
+                "failure_message": Status.INVALID_INPUT.value
+                + parse_serializer_errors(serializer.errors),
+                "errors": str(serializer.errors),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
-    rack_id = serializer.validated_data['rack'].id
+    rack_id = serializer.validated_data["rack"].id
     try:
         rack = Rack.objects.get(id=rack_id)
     except ObjectDoesNotExist:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.MODIFY_ERROR.value +
-                    "Rack" + GenericFailure.DOES_NOT_EXIST.value,
-                "errors": "No existing rack with id="+str(rack_id)
+                "failure_message": Status.MODIFY_ERROR.value
+                + "Rack"
+                + GenericFailure.DOES_NOT_EXIST.value,
+                "errors": "No existing rack with id=" + str(rack_id),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     if not user_has_asset_permission(request.user, rack.datacenter):
         return JsonResponse(
             {
-                "failure_message":
-                    Status.AUTH_ERROR.value + AuthFailure.ASSET.value,
-                "errors":
-                    "User " + request.user.username +
-                    " does not have asset permission in datacenter id="
-                    + str(rack.datacenter.id)
+                "failure_message": Status.AUTH_ERROR.value + AuthFailure.ASSET.value,
+                "errors": "User "
+                + request.user.username
+                + " does not have asset permission in datacenter id="
+                + str(rack.datacenter.id),
             },
-            status=HTTPStatus.UNAUTHORIZED
+            status=HTTPStatus.UNAUTHORIZED,
         )
-    rack_position = serializer.validated_data['rack_position']
-    height = serializer.validated_data['model'].height
+    rack_position = serializer.validated_data["rack_position"]
+    height = serializer.validated_data["model"].height
 
     try:
-        validate_asset_location(
-            rack_id,
-            rack_position,
-            height,
-            change_plan=change_plan
-        )
+        validate_asset_location(rack_id, rack_position, height, change_plan=change_plan)
     except LocationException as error:
         return JsonResponse(
             {"failure_message": Status.CREATE_ERROR.value + str(error)},
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     try:
         asset = serializer.save()
     except Exception as error:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.CREATE_ERROR.value +
-                    parse_save_validation_error(error, "Asset"),
-                "errors": str(error)
+                "failure_message": Status.CREATE_ERROR.value
+                + parse_save_validation_error(error, "Asset"),
+                "errors": str(error),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     warning_message = ""
     # TODO: CHANGE PLAN save power connections and network connections
 
     try:
-        save_mac_addresses(
-            asset_data=data,
-            asset_id=asset.id,
-            change_plan=change_plan
-        )
+        save_mac_addresses(asset_data=data, asset_id=asset.id, change_plan=change_plan)
     except MacAddressException as error:
-        warning_message += "Some mac addresses couldn't be saved. " + \
-            str(error)
+        warning_message += "Some mac addresses couldn't be saved. " + str(error)
 
     try:
         save_power_connections(
-            asset_data=data,
-            asset_id=asset.id,
-            change_plan=change_plan
+            asset_data=data, asset_id=asset.id, change_plan=change_plan
         )
     except PowerConnectionException as error:
-        warning_message += "Some power connections couldn't be saved. " + \
-            str(error)
+        warning_message += "Some power connections couldn't be saved. " + str(error)
     try:
         save_network_connections(
-            asset_data=data,
-            asset_id=asset.id,
-            change_plan=change_plan
+            asset_data=data, asset_id=asset.id, change_plan=change_plan
         )
         if not change_plan:
             log_network_action(request.user, asset)
     except NetworkConnectionException as error:
-        warning_message += "Some network connections couldn't be saved. " + \
-            str(error)
+        warning_message += "Some network connections couldn't be saved. " + str(error)
     if warning_message:
-        return JsonResponse(
-            {"warning_message": warning_message},
-            status=HTTPStatus.OK,
-        )
+        return JsonResponse({"warning_message": warning_message}, status=HTTPStatus.OK,)
     else:
         if change_plan:
             return JsonResponse(
                 {
-                    "success_message":
-                        Status.SUCCESS.value +
-                        "Asset created on change plan " +
-                        change_plan.name,
+                    "success_message": Status.SUCCESS.value
+                    + "Asset created on change plan "
+                    + change_plan.name,
                     "related_id": change_plan.id,
                 },
                 status=HTTPStatus.OK,
@@ -304,441 +278,42 @@ def asset_add(request):
             log_action(request.user, asset, Action.CREATE)
             return JsonResponse(
                 {
-                    "success_message":
-                        Status.SUCCESS.value +
-                        "Asset " + str(asset.asset_number) + " created"
+                    "success_message": Status.SUCCESS.value
+                    + "Asset "
+                    + str(asset.asset_number)
+                    + " created"
                 },
                 status=HTTPStatus.OK,
             )
 
 
-def save_mac_addresses(asset_data, asset_id, change_plan=None):
-    if (
-        'mac_addresses' not in asset_data
-        or not asset_data['mac_addresses']
-    ):
-        return
-    mac_address_assignments = asset_data['mac_addresses']
-    failure_message = ""
-    for port_name in mac_address_assignments.keys():
-        try:
-            if change_plan:
-                network_port = NetworkPortCP.objects.get(
-                    asset=asset_id,
-                    port_name=port_name,
-                    change_plan=change_plan
-                )
-            else:
-                network_port = NetworkPort.objects.get(
-                    asset=asset_id,
-                    port_name=port_name
-                )
-        except ObjectDoesNotExist:
-            failure_message += "Port name '"+port_name+"' is not valid. "
-        else:
-            mac_address = mac_address_assignments[port_name]
-            network_port.mac_address = mac_address
-            try:
-                network_port.save()
-            except Exception:
-                failure_message += \
-                    "Mac address '" + \
-                    mac_address + \
-                    "' is not valid. "
-    if failure_message:
-        raise MacAddressException(failure_message)
-
-
-def save_network_connections(asset_data, asset_id, change_plan=None):
-    if (
-        'network_connections' not in asset_data
-        or not asset_data['network_connections']
-    ):
-        return
-    network_connections = asset_data['network_connections']
-    failure_message = ""
-    for network_connection in network_connections:
-        port_name = network_connection['source_port']
-        try:
-            if change_plan:
-                network_port = NetworkPortCP.objects.get(
-                    asset=asset_id,
-                    port_name=port_name,
-                    change_plan=change_plan)
-            else:
-                network_port = NetworkPort.objects.get(
-                    asset=asset_id,
-                    port_name=port_name
-                )
-        except ObjectDoesNotExist:
-            failure_message += "Port name '"+port_name+"' is not valid. "
-        else:
-            if (
-                not network_connection['destination_hostname'] and
-                not network_connection['destination_port']
-            ):
-
-                if change_plan:
-                    # need to add deleted connection's asset to asset change plan
-                    asset_cp = AssetCP.objects.get(id=asset_id)
-                    if asset_cp.related_asset_id:
-                        asset_live = Asset.objects.get(
-                            id=asset_cp.related_asset_id
-                        )
-                        network_port_live = NetworkPort.objects.get(
-                            asset=asset_live, port_name=port_name
-                        )
-                        if network_port_live.connected_port:
-                            destination_port_live = NetworkPort.objects.filter(
-                                id=network_port_live.connected_port_id
-                            )[0]
-                            destination_asset_live = Asset.objects.get(
-                                id=destination_port_live.asset_id
-                            )
-                            destination_asset_cp = AssetCP(
-                                related_asset=destination_asset_live,
-                                change_plan=change_plan,
-                            )
-                        # add destination asset to AssetCPTable
-                        for field in destination_asset_live._meta.fields:
-                            if (
-                                field.name != 'id'
-                                and field.name != "assetid_ptr"
-                            ):
-                                setattr(
-                                    destination_asset_cp,
-                                    field.name,
-                                    getattr(destination_asset_live,
-                                            field.name),
-                                )
-
-                        destination_asset_cp.save()
-
-                        # Destination asset has been added to AssetCP, but its
-                        # network ports are empty (no connections/mac
-                        # addresses) get the network ports from the live asset
-                        dest_network_ports_live = NetworkPort.objects.filter(
-                            asset=destination_asset_live
-                        )
-                        for dest_network_port_live in dest_network_ports_live:
-                            # for each port, copy over mac address values
-                            dest_network_port_cp = NetworkPortCP.objects.get(
-                                asset=destination_asset_cp,
-                                port_name=dest_network_port_live.port_name,
-                            )
-                            dest_network_port_cp.mac_address = \
-                                dest_network_port_live.mac_address
-                            # also copy over the connected_port if there 1. is
-                            # a connection and 2. is not the port that is being
-                            # deleted in this PR
-                            if (
-                                dest_network_port_live.connected_port
-                                and not (dest_network_port_live.connected_port.port_name == port_name)
-                            ):
-                                dest_network_port_cp.connected_port = \
-                                    dest_network_port_live.connected_port
-                            dest_network_port_cp.save()
-                        # same dealio with power ports
-                        dest_power_ports_live = PowerPort.objects.filter(
-                            asset=destination_asset_live
-                        )
-                        for dest_power_port_live in dest_power_ports_live:
-                            dest_power_port_cp = PowerPortCP.objects.get(
-                                asset=destination_asset_cp,
-                                port_name=dest_power_port_live.port_name,
-                            )
-                            dest_pdu_live = \
-                                dest_power_port_live.power_connection
-                            # if the live power port had a pdu connection,
-                            # create/update the PDUs on PDUCP
-                            if dest_pdu_live:
-                                if PDUPortCP.objects.filter(
-                                    rack=dest_pdu_live.rack,
-                                    left_right=dest_pdu_live.left_right,
-                                    port_number=dest_pdu_live.port_number,
-                                    change_plan=change_plan,
-                                ).exists():
-                                    pdu_port = PDUPortCP.objects.filter(
-                                        rack=dest_pdu_live.rack,
-                                        left_right=dest_pdu_live.left_right,
-                                        port_number=dest_pdu_live.port_number,
-                                        change_plan=change_plan,
-                                    )
-                                else:
-                                    pdu_port = PDUPortCP(
-                                        change_plan=change_plan
-                                    )
-                                    for field in dest_pdu_live._meta.fields:
-                                        if field.name != "id":
-                                            setattr(
-                                                pdu_port,
-                                                field.name,
-                                                getattr(
-                                                    dest_pdu_live,
-                                                    field.name,
-                                                ),
-                                            )
-                                    pdu_port.save()
-                                dest_power_port_cp.power_connection = pdu_port
-                                dest_power_port_cp.save()
-
-                network_port.delete_network_connection()
-
-                continue
-            if (
-                not network_connection['destination_hostname']
-            ):
-                failure_message += "Could not create connection on port '" + \
-                    port_name + \
-                    "' because no destination hostname was provided."
-                continue
-            if (
-                not network_connection['destination_port']
-            ):
-                failure_message += "Could not create connection on port '" + \
-                    port_name + \
-                    "' because no destination port was provided."
-                continue
-            try:
-                if change_plan:
-                    assets, assets_cp = get_assets_for_cp(change_plan.id)
-                    if assets.filter(
-                        hostname=network_connection['destination_hostname']
-                    ).exists():
-                        destination_asset = assets.get(
-                            hostname=network_connection['destination_hostname']
-                        )
-                        asset_cp = AssetCP(
-                            related_asset=destination_asset,
-                            change_plan=change_plan
-                        )
-                        # add destination asset to AssetCPTable
-                        for field in destination_asset._meta.fields:
-                            if (
-                                field.name != 'id'
-                                and field.name != "assetid_ptr"
-                            ):
-                                setattr(
-                                    asset_cp,
-                                    field.name,
-                                    getattr(destination_asset, field.name),
-                                )
-                        asset_cp.save()
-                        # copy over mac address values, the actual connections
-                        # get made later in the create_network_connections()
-                        # method
-                        dest_network_ports_live = NetworkPort.objects.filter(
-                            asset=destination_asset
-                        )
-                        for dest_network_port_live in dest_network_ports_live:
-                            dest_network_port_cp = NetworkPortCP.objects.get(
-                                asset=asset_cp,
-                                port_name=dest_network_port_live.port_name,
-                            )
-                            dest_network_port_cp.mac_address = \
-                                dest_network_port_live.mac_address
-                            dest_network_port_cp.save()
-
-                        # power connection info
-                        dest_power_ports_live = PowerPort.objects.filter(
-                            asset=destination_asset
-                        )
-                        for dest_power_port_live in dest_power_ports_live:
-                            dest_power_port_cp = PowerPortCP.objects.get(
-                                asset=asset_cp,
-                                port_name=dest_power_port_live.port_name,
-                            )
-                            dest_pdu_live = \
-                                dest_power_port_live.power_connection
-                            if dest_pdu_live:
-                                if PDUPortCP.objects.filter(
-                                    rack=dest_pdu_live.rack,
-                                    left_right=dest_pdu_live.left_right,
-                                    port_number=dest_pdu_live.port_number,
-                                    change_plan=change_plan,
-                                ).exists():
-                                    pdu_port = PDUPortCP.objects.filter(
-                                        rack=dest_pdu_live.rack,
-                                        left_right=dest_pdu_live.left_right,
-                                        port_number=dest_pdu_live.port_number,
-                                        change_plan=change_plan,
-                                    )
-                                else:
-                                    pdu_port = PDUPortCP(
-                                        change_plan=change_plan
-                                    )
-                                    for field in dest_pdu_live._meta.fields:
-                                        if field.name != "id":
-                                            setattr(
-                                                pdu_port,
-                                                field.name,
-                                                getattr(
-                                                    dest_pdu_live,
-                                                    field.name,
-                                                ),
-                                            )
-                                    pdu_port.save()
-                                dest_power_port_cp.power_connection = pdu_port
-                                dest_power_port_cp.save()
-                        destination_asset = asset_cp
-
-                    else:
-                        destination_asset = assets_cp.get(
-                            hostname=network_connection['destination_hostname'],
-                            change_plan=change_plan,
-                        )
-                else:
-                    destination_asset = Asset.objects.get(
-                        hostname=network_connection['destination_hostname']
-                    )
-            except ObjectDoesNotExist:
-                failure_message += \
-                    "Asset with hostname '" + \
-                    network_connection['destination_hostname'] + \
-                    "' does not exist. "
-            else:
-                try:
-                    if change_plan:
-                        destination_port = NetworkPortCP.objects.get(
-                            asset=destination_asset,
-                            port_name=network_connection['destination_port'],
-                            change_plan=change_plan
-                        )
-                    else:
-                        destination_port = NetworkPort.objects.get(
-                            asset=destination_asset,
-                            port_name=network_connection['destination_port']
-                        )
-                except ObjectDoesNotExist:
-                    failure_message += \
-                        "Destination port '" + \
-                        network_connection['destination_hostname'] + \
-                        ":" + \
-                        network_connection['destination_port'] + \
-                        "' does not exist. "
-                else:
-                    try:
-                        network_port.create_network_connection(
-                            destination_port=destination_port
-                        )
-                    except Exception as error:
-                        failure_message += \
-                            "Could not save connection for port '" + \
-                            port_name + \
-                            "'. " + \
-                            str(error)
-    if failure_message:
-        raise NetworkConnectionException(failure_message)
-
-
-def save_power_connections(asset_data, asset_id, change_plan=None):
-    if (
-        'power_connections' not in asset_data
-        or not asset_data['power_connections']
-    ):
-        return
-    power_connection_assignments = asset_data['power_connections']
-    failure_message = ""
-    for port_name in power_connection_assignments.keys():
-        try:
-            if change_plan:
-                power_port = PowerPortCP.objects.get(
-                    asset=asset_id,
-                    port_name=port_name,
-                    change_plan=change_plan.id
-                )
-            else:
-                power_port = PowerPort.objects.get(
-                    asset=asset_id,
-                    port_name=port_name
-                )
-        except ObjectDoesNotExist:
-            failure_message += "Power port '"+port_name+"' does not exist on this asset. "
-        else:
-            power_connection_data = power_connection_assignments[port_name]
-            if change_plan:
-                asset = AssetCP.objects.get(id=asset_id)
-            else:
-                asset = Asset.objects.get(id=asset_id)
-            if not power_connection_data:
-                power_port.power_connection = None
-                power_port.save()
-                continue
-            try:
-                pdu_port_master = PDUPort.objects.get(
-                    rack=asset.rack,
-                    left_right=power_connection_data['left_right'],
-                    port_number=power_connection_data['port_number']
-                )
-                pdu_port = pdu_port_master
-                if change_plan:
-                    if PDUPortCP.objects.filter(
-                        rack=asset.rack,
-                        left_right=power_connection_data['left_right'],
-                        port_number=power_connection_data['port_number'],
-                        change_plan=change_plan
-                    ).exists():
-                        pdu_port = PDUPortCP.objects.get(
-                            rack=asset.rack,
-                            left_right=power_connection_data['left_right'],
-                            port_number=power_connection_data['port_number'],
-                            change_plan=change_plan
-                        )
-                    else:
-                        pdu_port = PDUPortCP(change_plan=change_plan)
-                        for field in pdu_port_master._meta.fields:
-                            if field.name != "id":
-                                setattr(pdu_port, field.name, getattr(
-                                    pdu_port_master, field.name))
-                        pdu_port.save()
-
-            except ObjectDoesNotExist:
-                failure_message += \
-                    "PDU port '" + \
-                    power_connection_data['left_right'] + \
-                    str(power_connection_data['port_number']) + \
-                    "' does not exist. "
-            else:
-                power_port.power_connection = pdu_port
-                try:
-                    power_port.save()
-                except Exception as error:
-                    failure_message += \
-                        "Power connection on port '" + \
-                        port_name + \
-                        "' of asset '" + \
-                        str(asset.asset_number) + \
-                        "' was not valid. "
-    if failure_message:
-        raise PowerConnectionException(failure_message)
-
-
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def asset_modify(request):
     """
     Modify a single existing asset
     """
     data = JSONParser().parse(request)
-    if 'id' not in data:
+    if "id" not in data:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.MODIFY_ERROR.value + GenericFailure.INTERNAL.value,
-                "errors": "Must include 'id' when modifying an asset"
+                "failure_message": Status.MODIFY_ERROR.value
+                + GenericFailure.INTERNAL.value,
+                "errors": "Must include 'id' when modifying an asset",
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
-    id = data['id']
+    id = data["id"]
     if request.query_params.get("change_plan"):
         (change_plan, response) = get_change_plan(
-            request.query_params.get("change_plan"))
+            request.query_params.get("change_plan")
+        )
         if response:
             return response
         response = get_cp_already_executed_response(change_plan)
         if response:
             return response
-        del data['id']
+        del data["id"]
     else:
         change_plan = None
 
@@ -753,75 +328,72 @@ def asset_modify(request):
             except ObjectDoesNotExist:
                 return JsonResponse(
                     {
-                        "failure_message":
-                            Status.MODIFY_ERROR.value +
-                            "Model" + GenericFailure.DOES_NOT_EXIST.value,
-                        "errors": "No existing asset with id="+str(id)
+                        "failure_message": Status.MODIFY_ERROR.value
+                        + "Model"
+                        + GenericFailure.DOES_NOT_EXIST.value,
+                        "errors": "No existing asset with id=" + str(id),
                     },
-                    status=HTTPStatus.BAD_REQUEST
+                    status=HTTPStatus.BAD_REQUEST,
                 )
             existing_asset = AssetCP(
-                change_plan=change_plan,
-                related_asset=existing_asset_master)
+                change_plan=change_plan, related_asset=existing_asset_master
+            )
             for field in existing_asset_master._meta.fields:
                 if not (field.name == "id" or field.name == "assetid_ptr"):
-                    setattr(existing_asset, field.name, getattr(
-                        existing_asset_master, field.name))
+                    setattr(
+                        existing_asset,
+                        field.name,
+                        getattr(existing_asset_master, field.name),
+                    )
     else:
         try:
             existing_asset = Asset.objects.get(id=id)
         except ObjectDoesNotExist:
             return JsonResponse(
                 {
-                    "failure_message":
-                        Status.MODIFY_ERROR.value +
-                        "Model" + GenericFailure.DOES_NOT_EXIST.value,
-                    "errors": "No existing asset with id="+str(id)
+                    "failure_message": Status.MODIFY_ERROR.value
+                    + "Model"
+                    + GenericFailure.DOES_NOT_EXIST.value,
+                    "errors": "No existing asset with id=" + str(id),
                 },
-                status=HTTPStatus.BAD_REQUEST
+                status=HTTPStatus.BAD_REQUEST,
             )
 
-    if not user_has_asset_permission(
-        request.user,
-        existing_asset.rack.datacenter
-    ):
+    if not user_has_asset_permission(request.user, existing_asset.rack.datacenter):
         return JsonResponse(
             {
-                "failure_message":
-                    Status.AUTH_ERROR.value + AuthFailure.ASSET.value,
-                "errors":
-                    "User " + request.user.username +
-                    " does not have asset permission in datacenter id="
-                    + str(existing_asset.rack.datacenter.id)
+                "failure_message": Status.AUTH_ERROR.value + AuthFailure.ASSET.value,
+                "errors": "User "
+                + request.user.username
+                + " does not have asset permission in datacenter id="
+                + str(existing_asset.rack.datacenter.id),
             },
-            status=HTTPStatus.UNAUTHORIZED
+            status=HTTPStatus.UNAUTHORIZED,
         )
     try:
         validate_location_modification(
-            data, existing_asset, request.user, change_plan=change_plan)
+            data, existing_asset, request.user, change_plan=change_plan
+        )
     except Exception as error:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.MODIFY_ERROR.value +
-                    "Invalid location change. " + str(error)
+                "failure_message": Status.MODIFY_ERROR.value
+                + "Invalid location change. "
+                + str(error)
             },
             status=HTTPStatus.BAD_REQUEST,
         )
     for field in data.keys():
-        if field == 'model':
+        if field == "model":
             value = ITModel.objects.get(id=data[field])
-        elif field == 'rack':
+        elif field == "rack":
             value = Rack.objects.get(id=data[field])
-        elif field == 'hostname' and data['hostname']:
+        elif field == "hostname" and data["hostname"]:
             if change_plan:
                 assets, assets_cp = get_assets_for_cp(change_plan.id)
-                assets_with_hostname = assets.filter(
-                    hostname__iexact=data[field]
-                )
+                assets_with_hostname = assets.filter(hostname__iexact=data[field])
                 if not (
-                    len(assets_with_hostname) > 0
-                    and assets_with_hostname[0].id != id
+                    len(assets_with_hostname) > 0 and assets_with_hostname[0].id != id
                 ):
                     assets_with_hostname = assets_cp.filter(
                         hostname__iexact=data[field]
@@ -830,37 +402,31 @@ def asset_modify(request):
                 assets_with_hostname = Asset.objects.filter(
                     hostname__iexact=data[field]
                 )
-            if (
-                len(assets_with_hostname) > 0
-                and assets_with_hostname[0].id != id
-            ):
+            if len(assets_with_hostname) > 0 and assets_with_hostname[0].id != id:
                 return JsonResponse(
                     {
-                        "failure_message":
-                            Status.MODIFY_ERROR.value +
-                            "Asset with hostname '" +
-                            data[field].lower() + "' already exists."
+                        "failure_message": Status.MODIFY_ERROR.value
+                        + "Asset with hostname '"
+                        + data[field].lower()
+                        + "' already exists."
                     },
                     status=HTTPStatus.BAD_REQUEST,
                 )
 
             value = data[field]
-        elif field == 'asset_number':
+        elif field == "asset_number":
             if change_plan:
                 try:
                     validate_asset_number_uniqueness(
-                        data[field],
-                        id,
-                        change_plan,
-                        existing_asset.related_asset,
+                        data[field], id, change_plan, existing_asset.related_asset,
                     )
                 except ValidationError:
                     return JsonResponse(
                         {
-                            "failure_message":
-                                Status.MODIFY_ERROR.value +
-                                "Asset with asset number '" +
-                                str(data[field]) + "' already exists."
+                            "failure_message": Status.MODIFY_ERROR.value
+                            + "Asset with asset number '"
+                            + str(data[field])
+                            + "' already exists."
                         },
                         status=HTTPStatus.BAD_REQUEST,
                     )
@@ -870,15 +436,16 @@ def asset_modify(request):
                     asset_number=data[field]
                 )
                 if (
-                    data[field] and len(assets_with_asset_number) > 0
+                    data[field]
+                    and len(assets_with_asset_number) > 0
                     and assets_with_asset_number[0].id != existing_asset.id
                 ):
                     return JsonResponse(
                         {
-                            "failure_message":
-                                Status.MODIFY_ERROR.value +
-                                "Asset with asset number '" +
-                                str(data[field]) + "' already exists."
+                            "failure_message": Status.MODIFY_ERROR.value
+                            + "Asset with asset number '"
+                            + str(data[field])
+                            + "' already exists."
                         },
                         status=HTTPStatus.BAD_REQUEST,
                     )
@@ -892,122 +459,108 @@ def asset_modify(request):
     except Exception as error:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.MODIFY_ERROR.value +
-                    parse_save_validation_error(error, "Asset"),
-                "errors": str(error)
+                "failure_message": Status.MODIFY_ERROR.value
+                + parse_save_validation_error(error, "Asset"),
+                "errors": str(error),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     else:
         warning_message = ""
         try:
             save_mac_addresses(
-                asset_data=data,
-                asset_id=existing_asset.id,
-                change_plan=change_plan
+                asset_data=data, asset_id=existing_asset.id, change_plan=change_plan
             )
         except MacAddressException as error:
-            warning_message += "Some mac addresses couldn't be saved. " + \
-                str(error)
+            warning_message += "Some mac addresses couldn't be saved. " + str(error)
         try:
             save_power_connections(
-                asset_data=data,
-                asset_id=existing_asset.id,
-                change_plan=change_plan
+                asset_data=data, asset_id=existing_asset.id, change_plan=change_plan
             )
         except PowerConnectionException as error:
-            warning_message += "Some power connections couldn't be saved. " + \
-                str(error)
+            warning_message += "Some power connections couldn't be saved. " + str(error)
         try:
             save_network_connections(
-                asset_data=data,
-                asset_id=existing_asset.id,
-                change_plan=change_plan
+                asset_data=data, asset_id=existing_asset.id, change_plan=change_plan
             )
             if not change_plan:
                 log_network_action(request.user, existing_asset)
         except NetworkConnectionException as error:
-            warning_message += \
-                "Some network connections couldn't be saved. " + str(error)
+            warning_message += "Some network connections couldn't be saved. " + str(
+                error
+            )
         if warning_message:
             return JsonResponse(
-                {"warning_message": warning_message},
-                status=HTTPStatus.OK,
+                {"warning_message": warning_message}, status=HTTPStatus.OK,
             )
         else:
             if not change_plan:
                 log_action(request.user, existing_asset, Action.MODIFY)
                 return JsonResponse(
                     {
-                        "success_message":
-                            Status.SUCCESS.value +
-                            "Asset " +
-                        str(existing_asset.asset_number) + " modified"
+                        "success_message": Status.SUCCESS.value
+                        + "Asset "
+                        + str(existing_asset.asset_number)
+                        + " modified"
                     },
                     status=HTTPStatus.OK,
                 )
             else:
                 return JsonResponse(
                     {
-                        "success_message":
-                            Status.SUCCESS.value +
-                            "Asset modified on change plan " +
-                            change_plan.name,
+                        "success_message": Status.SUCCESS.value
+                        + "Asset modified on change plan "
+                        + change_plan.name,
                         "related_id": change_plan.id,
                     },
                     status=HTTPStatus.OK,
                 )
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def asset_delete(request):
     """
     Delete a single existing asset
     """
     data = JSONParser().parse(request)
-    if 'id' not in data:
+    if "id" not in data:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.DELETE_ERROR.value + GenericFailure.INTERNAL.value,
-                "errors": "Must include 'id' when deleting an asset"
+                "failure_message": Status.DELETE_ERROR.value
+                + GenericFailure.INTERNAL.value,
+                "errors": "Must include 'id' when deleting an asset",
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
-    id = data['id']
+    id = data["id"]
     try:
         existing_asset = Asset.objects.get(id=id)
     except ObjectDoesNotExist:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.DELETE_ERROR.value +
-                    "Model" + GenericFailure.DOES_NOT_EXIST.value,
-                "errors": "No existing asset with id="+str(id)
+                "failure_message": Status.DELETE_ERROR.value
+                + "Model"
+                + GenericFailure.DOES_NOT_EXIST.value,
+                "errors": "No existing asset with id=" + str(id),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
-    if not user_has_asset_permission(
-        request.user,
-        existing_asset.rack.datacenter
-    ):
+    if not user_has_asset_permission(request.user, existing_asset.rack.datacenter):
         return JsonResponse(
             {
-                "failure_message":
-                    Status.AUTH_ERROR.value + AuthFailure.ASSET.value,
-                "errors":
-                    "User " + request.user.username +
-                    " does not have asset permission in datacenter id="
-                    + str(existing_asset.rack.datacenter.id)
+                "failure_message": Status.AUTH_ERROR.value + AuthFailure.ASSET.value,
+                "errors": "User "
+                + request.user.username
+                + " does not have asset permission in datacenter id="
+                + str(existing_asset.rack.datacenter.id),
             },
-            status=HTTPStatus.UNAUTHORIZED
+            status=HTTPStatus.UNAUTHORIZED,
         )
     asset_number = existing_asset.asset_number
-    if (existing_asset.hostname):
+    if existing_asset.hostname:
         asset_hostname = existing_asset.hostname
-        asset_log_name = str(asset_number) + ' (' + asset_hostname + ')'
+        asset_log_name = str(asset_number) + " (" + asset_hostname + ")"
     else:
         asset_log_name = str(asset_number)
     try:
@@ -1015,65 +568,58 @@ def asset_delete(request):
     except Exception as error:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.DELETE_ERROR.value +
-                    "Asset" +
-                    GenericFailure.ON_DELETE.value,
-                "errors": str(error)
+                "failure_message": Status.DELETE_ERROR.value
+                + "Asset"
+                + GenericFailure.ON_DELETE.value,
+                "errors": str(error),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     log_delete(request.user, ElementType.ASSET, asset_log_name)
     return JsonResponse(
         {
-            "success_message":
-                Status.SUCCESS.value +
-                "Asset " + str(asset_number) + " deleted"
+            "success_message": Status.SUCCESS.value
+            + "Asset "
+            + str(asset_number)
+            + " deleted"
         },
-        status=HTTPStatus.OK
+        status=HTTPStatus.OK,
     )
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def asset_bulk_upload(request):
     """
     Bulk upload many assets to add or modify
     """
     data = JSONParser().parse(request)
-    if 'import_csv' not in data:
+    if "import_csv" not in data:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.IMPORT_ERROR.value +
-                    BulkFailure.IMPORT.value,
-                "errors":
-                    "Bulk upload request should have a parameter 'import_csv'"
+                "failure_message": Status.IMPORT_ERROR.value + BulkFailure.IMPORT.value,
+                "errors": "Bulk upload request should have a parameter 'import_csv'",
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
-    base_64_csv = data['import_csv']
-    csv_bytes_io = BytesIO(
-        b64decode(re.sub(".*base64,", '', base_64_csv))
-    )
-    csv_string_io = StringIO(csv_bytes_io.read().decode('UTF-8-SIG'))
-    csvReader = csv.DictReader(csv_string_io)
+    base_64_csv = data["import_csv"]
+    csv_bytes_io = BytesIO(b64decode(re.sub(".*base64,", "", base_64_csv)))
+    csv_string_io = StringIO(csv_bytes_io.read().decode("UTF-8-SIG"))
+    csv_reader = csv.DictReader(csv_string_io)
     expected_fields = BulkAssetSerializer.Meta.fields
-    given_fields = csvReader.fieldnames
-    if (
-        len(expected_fields) != len(given_fields)  # check for repeated fields
-        or set(expected_fields) != set(given_fields)
-    ):
+    given_fields = csv_reader.fieldnames
+    if len(expected_fields) != len(given_fields) or set(  # check for repeated fields
+        expected_fields
+    ) != set(given_fields):
         return JsonResponse(
             {
-                "failure_message":
-                    Status.IMPORT_ERROR.value +
-                    BulkFailure.IMPORT_COLUMNS.value
+                "failure_message": Status.IMPORT_ERROR.value
+                + BulkFailure.IMPORT_COLUMNS.value
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     bulk_asset_datas = []
-    for row in csvReader:
+    for row in csv_reader:
         bulk_asset_datas.append(dict(row))
     assets_to_add = []
     potential_modifications = []
@@ -1086,52 +632,51 @@ def asset_bulk_upload(request):
         asset_datas.append(asset_data)
         try:
             model = ITModel.objects.get(
-                vendor=asset_data['vendor'],
-                model_number=asset_data['model_number']
+                vendor=asset_data["vendor"], model_number=asset_data["model_number"]
             )
         except ObjectDoesNotExist:
-            failure_message = Status.IMPORT_ERROR.value + \
-                "Model does not exist: " + \
-                "vendor="+asset_data['vendor'] + \
-                ", model_number="+asset_data['model_number']
+            failure_message = (
+                Status.IMPORT_ERROR.value
+                + "Model does not exist: "
+                + "vendor="
+                + asset_data["vendor"]
+                + ", model_number="
+                + asset_data["model_number"]
+            )
             return JsonResponse(
-                {"failure_message": failure_message},
-                status=HTTPStatus.BAD_REQUEST
+                {"failure_message": failure_message}, status=HTTPStatus.BAD_REQUEST
             )
-        asset_data['model'] = model.id
-        del asset_data['vendor']
-        del asset_data['model_number']
+        asset_data["model"] = model.id
+        del asset_data["vendor"]
+        del asset_data["model_number"]
         try:
-            datacenter = Datacenter.objects.get(
-                abbreviation=asset_data['datacenter']
-            )
+            datacenter = Datacenter.objects.get(abbreviation=asset_data["datacenter"])
         except ObjectDoesNotExist:
-            failure_message = Status.IMPORT_ERROR.value + \
-                "Provided datacenter doesn't exist: " + \
-                asset_data['datacenter']
+            failure_message = (
+                Status.IMPORT_ERROR.value
+                + "Provided datacenter doesn't exist: "
+                + asset_data["datacenter"]
+            )
             return JsonResponse(
-                {"failure_message": failure_message},
-                status=HTTPStatus.BAD_REQUEST
+                {"failure_message": failure_message}, status=HTTPStatus.BAD_REQUEST
             )
         try:
-            row_letter = asset_data['rack'][:1].upper()
-            rack_num = asset_data['rack'][1:]
+            row_letter = asset_data["rack"][:1].upper()
+            rack_num = asset_data["rack"][1:]
             rack = Rack.objects.get(
-                datacenter=datacenter,
-                row_letter=row_letter,
-                rack_num=rack_num
+                datacenter=datacenter, row_letter=row_letter, rack_num=rack_num
             )
         except ObjectDoesNotExist:
-            failure_message = Status.IMPORT_ERROR.value + \
-                "Provided rack doesn't exist: " + \
-                asset_data['rack']
-            return JsonResponse(
-                {"failure_message": failure_message},
-                status=HTTPStatus.BAD_REQUEST
+            failure_message = (
+                Status.IMPORT_ERROR.value
+                + "Provided rack doesn't exist: "
+                + asset_data["rack"]
             )
-        asset_data['rack'] = rack.id
-        asset_serializer = AssetSerializer(
-            data=asset_data)  # non-recursive to validate
+            return JsonResponse(
+                {"failure_message": failure_message}, status=HTTPStatus.BAD_REQUEST
+            )
+        asset_data["rack"] = rack.id
+        asset_serializer = AssetSerializer(data=asset_data)  # non-recursive to validate
         if not asset_serializer.is_valid():
             errors = asset_serializer.errors
             if not (
@@ -1139,64 +684,65 @@ def asset_bulk_upload(request):
                 # hostname uniqueness, that's fine - it's a modify
                 (
                     len(errors.keys()) == 2  # known bug here!
-                    and 'hostname' in errors
-                    and len(errors['hostname']) == 1
-                    and errors['hostname'][0].code == 'unique'
-                    and 'asset_number' in errors
-                    and len(errors['asset_number']) == 1
-                    and errors['asset_number'][0].code == 'unique'
+                    and "hostname" in errors
+                    and len(errors["hostname"]) == 1
+                    and errors["hostname"][0].code == "unique"
+                    and "asset_number" in errors
+                    and len(errors["asset_number"]) == 1
+                    and errors["asset_number"][0].code == "unique"
                 )
-                or
-                (
+                or (
                     len(errors.keys()) == 1
-                    and 'asset_number' in errors
-                    and len(errors['asset_number']) == 1
-                    and errors['asset_number'][0].code == 'unique'
+                    and "asset_number" in errors
+                    and len(errors["asset_number"]) == 1
+                    and errors["asset_number"][0].code == "unique"
                 )
             ):
                 return JsonResponse(
                     {
-                        "failure_message":
-                            Status.IMPORT_ERROR.value +
-                            BulkFailure.ASSET_INVALID.value +
-                            parse_serializer_errors(asset_serializer.errors),
-                        "errors": str(asset_serializer.errors)
+                        "failure_message": Status.IMPORT_ERROR.value
+                        + BulkFailure.ASSET_INVALID.value
+                        + parse_serializer_errors(asset_serializer.errors),
+                        "errors": str(asset_serializer.errors),
                     },
-                    status=HTTPStatus.BAD_REQUEST
+                    status=HTTPStatus.BAD_REQUEST,
                 )
         # Check that all hostnames in file are case insensitive unique
-        if 'hostname' in asset_data and asset_data['hostname']:
-            asset_data_hostname_lower = asset_data['hostname'].lower()
+        if "hostname" in asset_data and asset_data["hostname"]:
+            asset_data_hostname_lower = asset_data["hostname"].lower()
             if asset_data_hostname_lower in hostnames_in_import:
-                failure_message = Status.IMPORT_ERROR.value + \
-                    "Hostname must be unique, but '" + \
-                    asset_data_hostname_lower + \
-                    "' appears more than once in import. "
+                failure_message = (
+                    Status.IMPORT_ERROR.value
+                    + "Hostname must be unique, but '"
+                    + asset_data_hostname_lower
+                    + "' appears more than once in import. "
+                )
                 return JsonResponse(
-                    {"failure_message": failure_message},
-                    status=HTTPStatus.BAD_REQUEST
+                    {"failure_message": failure_message}, status=HTTPStatus.BAD_REQUEST
                 )
             else:
                 hostnames_in_import.add(asset_data_hostname_lower)
         # Check that all asset_numbers in file are unique
-        if 'asset_number' in asset_data and asset_data['asset_number']:
-            asset_number = asset_data['asset_number']
+        if "asset_number" in asset_data and asset_data["asset_number"]:
+            asset_number = asset_data["asset_number"]
             if asset_number in asset_numbers_in_import:
-                failure_message = Status.IMPORT_ERROR.value + \
-                    "Asset number must be unique, but '" + \
-                    str(asset_number) + \
-                    "' appears more than once in import. "
+                failure_message = (
+                    Status.IMPORT_ERROR.value
+                    + "Asset number must be unique, but '"
+                    + str(asset_number)
+                    + "' appears more than once in import. "
+                )
                 return JsonResponse(
-                    {"failure_message": failure_message},
-                    status=HTTPStatus.BAD_REQUEST
+                    {"failure_message": failure_message}, status=HTTPStatus.BAD_REQUEST
                 )
             else:
                 asset_numbers_in_import.add(asset_number)
         asset_exists = False
-        if 'asset_number' in asset_data and asset_data['asset_number']:
+        if "asset_number" in asset_data and asset_data["asset_number"]:
             try:
                 existing_asset = Asset.objects.get(
-                    asset_number=asset_data['asset_number'])
+                    asset_number=asset_data["asset_number"]
+                )
             except ObjectDoesNotExist:
                 pass
             else:
@@ -1205,204 +751,175 @@ def asset_bulk_upload(request):
             # asset number specfies existing asset
             try:
                 validate_location_modification(
-                    asset_data,
-                    existing_asset,
-                    request.user,
+                    asset_data, existing_asset, request.user,
                 )
             except Exception:
-                failure_message = Status.IMPORT_ERROR.value + \
-                    "Asset " + \
-                    str(asset_data['asset_number']) + \
-                    " would conflict location with an existing asset. "
+                failure_message = (
+                    Status.IMPORT_ERROR.value
+                    + "Asset "
+                    + str(asset_data["asset_number"])
+                    + " would conflict location with an existing asset. "
+                )
                 return JsonResponse(
-                    {"failure_message": failure_message},
-                    status=HTTPStatus.BAD_REQUEST
+                    {"failure_message": failure_message}, status=HTTPStatus.BAD_REQUEST
                 )
             potential_modifications.append(
-                {
-                    "existing_asset": existing_asset,
-                    "new_data": asset_data
-                }
+                {"existing_asset": existing_asset, "new_data": asset_data}
             )
         else:
             # asset number not provided or it is new
-            rack = asset_serializer.validated_data['rack']
+            rack = asset_serializer.validated_data["rack"]
             if not user_has_asset_permission(request.user, rack.datacenter):
                 return JsonResponse(
                     {
-                        "failure_message":
-                            Status.AUTH_ERROR.value + AuthFailure.ASSET.value,
-                        "errors":
-                            "User " + request.user.username +
-                            " does not have asset permission in datacenter id="
-                            + str(rack.datacenter.id)
+                        "failure_message": Status.AUTH_ERROR.value
+                        + AuthFailure.ASSET.value,
+                        "errors": "User "
+                        + request.user.username
+                        + " does not have asset permission in datacenter id="
+                        + str(rack.datacenter.id),
                     },
-                    status=HTTPStatus.UNAUTHORIZED
+                    status=HTTPStatus.UNAUTHORIZED,
                 )
-            model = ITModel.objects.get(id=asset_data['model'])
+            model = ITModel.objects.get(id=asset_data["model"])
             try:
                 validate_asset_location(
-                    asset_serializer.validated_data['rack'].id,
-                    asset_serializer.validated_data['rack_position'],
+                    asset_serializer.validated_data["rack"].id,
+                    asset_serializer.validated_data["rack_position"],
                     model.height,
                     asset_id=None,
                 )
             except LocationException as error:
-                if 'asset_number' in asset_data and asset_data['asset_number']:
-                    asset_name = str(asset_data['asset_number'])
-                elif 'hostname' in asset_data and asset_data['hostname']:
-                    asset_name = asset_data['hostname']
+                if "asset_number" in asset_data and asset_data["asset_number"]:
+                    asset_name = str(asset_data["asset_number"])
+                elif "hostname" in asset_data and asset_data["hostname"]:
+                    asset_name = asset_data["hostname"]
                 else:
                     asset_name = ""
                 return JsonResponse(
                     {
-                        "failure_message":
-                            Status.IMPORT_ERROR.value +
-                            "Asset " + asset_name +
-                            " is invalid. " + str(error)
+                        "failure_message": Status.IMPORT_ERROR.value
+                        + "Asset "
+                        + asset_name
+                        + " is invalid. "
+                        + str(error)
                     },
-                    status=HTTPStatus.BAD_REQUEST
+                    status=HTTPStatus.BAD_REQUEST,
                 )
             else:
                 assets_to_add.append(
-                    {
-                        "asset_serializer": asset_serializer,
-                        "asset_data": asset_data
-                    }
+                    {"asset_serializer": asset_serializer, "asset_data": asset_data}
                 )
     try:
         no_infile_location_conflicts(asset_datas)
     except LocationException as error:
-        failure_message = Status.IMPORT_ERROR.value + \
-            "Location conflicts among assets in import file. " + \
-            str(error)
+        failure_message = (
+            Status.IMPORT_ERROR.value
+            + "Location conflicts among assets in import file. "
+            + str(error)
+        )
         return JsonResponse(
-            {"failure_message": failure_message},
-            status=HTTPStatus.BAD_REQUEST
+            {"failure_message": failure_message}, status=HTTPStatus.BAD_REQUEST
         )
     records_added = 0
     for asset_to_add in assets_to_add:
         records_added += 1
-        asset_serializer = asset_to_add['asset_serializer']
-        asset_data = asset_to_add['asset_data']
+        asset_serializer = asset_to_add["asset_serializer"]
+        asset_data = asset_to_add["asset_data"]
         asset_added = asset_serializer.save()
         try:
-            save_power_connections(
-                asset_data=asset_data,
-                asset_id=asset_added.id
-            )
+            save_power_connections(asset_data=asset_data, asset_id=asset_added.id)
         except PowerConnectionException as error:
-            warning_message += "Some power connections couldn't be saved. " + \
-                str(error)
+            warning_message += "Some power connections couldn't be saved. " + str(error)
     records_ignored = 0
     modifications_to_approve = []
     for potential_modification in potential_modifications:
-        new_data = potential_modification['new_data']
-        new_data['model'] = ITModelSerializer(
-            ITModel.objects.get(id=new_data['model'])
+        new_data = potential_modification["new_data"]
+        new_data["model"] = ITModelSerializer(
+            ITModel.objects.get(id=new_data["model"])
         ).data
-        new_data['rack'] = RackSerializer(
-            Rack.objects.get(id=new_data['rack'])
-        ).data
+        new_data["rack"] = RackSerializer(Rack.objects.get(id=new_data["rack"])).data
         existing_data = RecursiveAssetSerializer(
-            potential_modification['existing_asset']
+            potential_modification["existing_asset"]
         ).data
         # macs and connections aren't specified in this file, so ignore them
-        del existing_data['mac_addresses']
-        del existing_data['network_connections']
-        del existing_data['network_graph']
+        del existing_data["mac_addresses"]
+        del existing_data["network_connections"]
+        del existing_data["network_graph"]
         if records_are_identical(existing_data, new_data):
             records_ignored += 1
         else:
-            new_data['id'] = existing_data['id']
+            new_data["id"] = existing_data["id"]
             for field in existing_data.keys():
                 if field not in new_data:
                     new_data[field] = None
             modifications_to_approve.append(
-                {
-                    "existing": existing_data,
-                    "modified": new_data
-                }
+                {"existing": existing_data, "modified": new_data}
             )
     response = {
         "added": records_added,
         "ignored": records_ignored,
-        "modifications": modifications_to_approve
+        "modifications": modifications_to_approve,
     }
     if warning_message:
-        response['warning_message'] = warning_message
+        response["warning_message"] = warning_message
     log_bulk_upload(
         request.user,
         ElementType.ASSET,
         records_added,
         records_ignored,
-        len(modifications_to_approve)
+        len(modifications_to_approve),
     )
-    return JsonResponse(
-        response,
-        status=HTTPStatus.OK
-    )
+    return JsonResponse(response, status=HTTPStatus.OK)
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def asset_bulk_approve(request):
     """
     Bulk approve many assets to modify
     """
     data = JSONParser().parse(request)
-    if 'approved_modifications' not in data:
+    if "approved_modifications" not in data:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.IMPORT_ERROR.value +
-                    BulkFailure.IMPORT.value,
-                "errors":
-                    "Bulk approve request should have a parameter " +
-                    "'approved_modifications'"
+                "failure_message": Status.IMPORT_ERROR.value + BulkFailure.IMPORT.value,
+                "errors": "Bulk approve request should have a parameter "
+                + "'approved_modifications'",
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
-    asset_datas = data['approved_modifications']
+    asset_datas = data["approved_modifications"]
     # Don't do any validation here because we know we sent valid assets to the
     # frontend, and they should send the same ones back
     warning_message = ""
     for asset_data in asset_datas:
-        existing_asset = Asset.objects.get(
-            id=asset_data['id'])
+        existing_asset = Asset.objects.get(id=asset_data["id"])
         for field in asset_data.keys():
             # This is assumed to have all fields, and with null values for
             # blank ones. That's how it's returned in bulk-upload
-            if field == 'model':
-                value = ITModel.objects.get(id=asset_data[field]['id'])
-            elif field == 'rack':
-                value = Rack.objects.get(id=asset_data[field]['id'])
+            if field == "model":
+                value = ITModel.objects.get(id=asset_data[field]["id"])
+            elif field == "rack":
+                value = Rack.objects.get(id=asset_data[field]["id"])
             else:
                 value = asset_data[field]
             setattr(existing_asset, field, value)
         existing_asset.save()
         try:
-            save_power_connections(
-                asset_data=asset_data,
-                asset_id=existing_asset.id
-            )
+            save_power_connections(asset_data=asset_data, asset_id=existing_asset.id)
         except PowerConnectionException as error:
-            warning_message += "Some power connections couldn't be saved. " + \
-                str(error)
+            warning_message += "Some power connections couldn't be saved. " + str(error)
     log_bulk_approve(request.user, ElementType.ASSET, len(asset_datas))
     if warning_message:
-        return JsonResponse(
-            {"warning_message": warning_message},
-            status=HTTPStatus.OK
-        )
+        return JsonResponse({"warning_message": warning_message}, status=HTTPStatus.OK)
     else:
         return JsonResponse(
-            {"success_message": "Assets succesfully modified. "},
-            status=HTTPStatus.OK
+            {"success_message": "Assets succesfully modified. "}, status=HTTPStatus.OK
         )
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def asset_bulk_export(request):
     """
@@ -1414,11 +931,11 @@ def asset_bulk_export(request):
     except Exception as error:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.EXPORT_ERROR.value + GenericFailure.FILTER.value,
-                "errors": str(error)
+                "failure_message": Status.EXPORT_ERROR.value
+                + GenericFailure.FILTER.value,
+                "errors": str(error),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     for filter_arg in filter_args:
         assets_query = assets_query.filter(**filter_arg)
@@ -1428,11 +945,11 @@ def asset_bulk_export(request):
     except Exception as error:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.EXPORT_ERROR.value + GenericFailure.SORT.value,
-                "errors": str(error)
+                "failure_message": Status.EXPORT_ERROR.value
+                + GenericFailure.SORT.value,
+                "errors": str(error),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     assets = assets_query.order_by(*sort_args)
 
@@ -1442,128 +959,115 @@ def asset_bulk_export(request):
     csv_writer = csv.DictWriter(csv_string, fields)
     csv_writer.writeheader()
     csv_writer.writerows(serializer.data)
-    return JsonResponse(
-        {"export_csv": csv_string.getvalue()},
-        status=HTTPStatus.OK,
-    )
+    return JsonResponse({"export_csv": csv_string.getvalue()}, status=HTTPStatus.OK,)
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def network_bulk_upload(request):
     data = JSONParser().parse(request)
-    if 'import_csv' not in data:
+    if "import_csv" not in data:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.IMPORT_ERROR.value +
-                    BulkFailure.IMPORT.value,
-                "errors":
-                    "Bulk upload request should have a parameter 'import_csv'"
+                "failure_message": Status.IMPORT_ERROR.value + BulkFailure.IMPORT.value,
+                "errors": "Bulk upload request should have a parameter 'import_csv'",
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
-    base_64_csv = data['import_csv']
-    csv_bytes_io = BytesIO(
-        b64decode(re.sub(".*base64,", '', base_64_csv))
-    )
-    csv_string_io = StringIO(csv_bytes_io.read().decode('UTF-8-SIG'))
-    csvReader = csv.DictReader(csv_string_io)
+    base_64_csv = data["import_csv"]
+    csv_bytes_io = BytesIO(b64decode(re.sub(".*base64,", "", base_64_csv)))
+    csv_string_io = StringIO(csv_bytes_io.read().decode("UTF-8-SIG"))
+    csv_reader = csv.DictReader(csv_string_io)
     expected_fields = BulkNetworkPortSerializer.Meta.fields
-    given_fields = csvReader.fieldnames
-    if (
-        len(expected_fields) != len(given_fields)  # check for repeated fields
-        or set(expected_fields) != set(given_fields)
-    ):
+    given_fields = csv_reader.fieldnames
+    if len(expected_fields) != len(given_fields) or set(  # check for repeated fields
+        expected_fields
+    ) != set(given_fields):
         return JsonResponse(
             {
-                "failure_message":
-                    Status.IMPORT_ERROR.value +
-                    BulkFailure.IMPORT_COLUMNS.value
+                "failure_message": Status.IMPORT_ERROR.value
+                + BulkFailure.IMPORT_COLUMNS.value
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     bulk_network_port_datas = []
-    for row in csvReader:
+    for row in csv_reader:
         bulk_network_port_datas.append(dict(row))
     num_ports_ignored = 0
     modifications_to_approve = []
     for bulk_network_port_data in bulk_network_port_datas:
         if (
-            'src_hostname' not in bulk_network_port_data
-            or not bulk_network_port_data['src_hostname']
+            "src_hostname" not in bulk_network_port_data
+            or not bulk_network_port_data["src_hostname"]
         ):
-            failure_message = Status.IMPORT_ERROR.value + \
-                "Field 'src_hostname' is required for all network imports."
+            failure_message = (
+                Status.IMPORT_ERROR.value
+                + "Field 'src_hostname' is required for all network imports."
+            )
             return JsonResponse(
-                {"failure_message": failure_message},
-                status=HTTPStatus.BAD_REQUEST
+                {"failure_message": failure_message}, status=HTTPStatus.BAD_REQUEST
             )
         if (
-            'src_port' not in bulk_network_port_data
-            or not bulk_network_port_data['src_port']
+            "src_port" not in bulk_network_port_data
+            or not bulk_network_port_data["src_port"]
         ):
-            failure_message = Status.IMPORT_ERROR.value + \
-                "Field 'src_port' is required for all network imports."
+            failure_message = (
+                Status.IMPORT_ERROR.value
+                + "Field 'src_port' is required for all network imports."
+            )
             return JsonResponse(
-                {"failure_message": failure_message},
-                status=HTTPStatus.BAD_REQUEST
+                {"failure_message": failure_message}, status=HTTPStatus.BAD_REQUEST
             )
         try:
             source_asset = Asset.objects.get(
-                hostname=bulk_network_port_data['src_hostname']
+                hostname=bulk_network_port_data["src_hostname"]
             )
         except ObjectDoesNotExist:
-            failure_message = Status.IMPORT_ERROR.value + \
-                "Source asset '" + \
-                bulk_network_port_data['src_hostname'] + \
-                "' does not exist. "
-            return JsonResponse(
-                {"failure_message": failure_message},
-                status=HTTPStatus.BAD_REQUEST
+            failure_message = (
+                Status.IMPORT_ERROR.value
+                + "Source asset '"
+                + bulk_network_port_data["src_hostname"]
+                + "' does not exist. "
             )
-        if not user_has_asset_permission(
-            request.user,
-            source_asset.rack.datacenter
-        ):
+            return JsonResponse(
+                {"failure_message": failure_message}, status=HTTPStatus.BAD_REQUEST
+            )
+        if not user_has_asset_permission(request.user, source_asset.rack.datacenter):
             return JsonResponse(
                 {
-                    "failure_message":
-                        Status.AUTH_ERROR.value + AuthFailure.ASSET.value,
-                    "errors":
-                        "User " + request.user.username +
-                        " does not have asset permission in datacenter id="
-                        + str(source_asset.rack.datacenter.id)
+                    "failure_message": Status.AUTH_ERROR.value
+                    + AuthFailure.ASSET.value,
+                    "errors": "User "
+                    + request.user.username
+                    + " does not have asset permission in datacenter id="
+                    + str(source_asset.rack.datacenter.id),
                 },
-                status=HTTPStatus.UNAUTHORIZED
+                status=HTTPStatus.UNAUTHORIZED,
             )
         try:
             existing_port = NetworkPort.objects.get(
-                asset=source_asset,
-                port_name=bulk_network_port_data['src_port']
+                asset=source_asset, port_name=bulk_network_port_data["src_port"]
             )
         except ObjectDoesNotExist:
-            failure_message = Status.IMPORT_ERROR.value + \
-                "Source port '" + \
-                bulk_network_port_data['src_port'] + \
-                "' does not exist on asset '" + \
-                bulk_network_port_data['src_hostname'] + \
-                "'. "
+            failure_message = (
+                Status.IMPORT_ERROR.value
+                + "Source port '"
+                + bulk_network_port_data["src_port"]
+                + "' does not exist on asset '"
+                + bulk_network_port_data["src_hostname"]
+                + "'. "
+            )
             return JsonResponse(
-                {"failure_message": failure_message},
-                status=HTTPStatus.BAD_REQUEST
+                {"failure_message": failure_message}, status=HTTPStatus.BAD_REQUEST
             )
         existing_port_serializer = BulkNetworkPortSerializer(existing_port)
-        if records_are_identical(
-            bulk_network_port_data,
-            existing_port_serializer.data
-        ):
+        if records_are_identical(bulk_network_port_data, existing_port_serializer.data):
             num_ports_ignored += 1
         else:
             modifications_to_approve.append(
                 {
                     "existing": existing_port_serializer.data,
-                    "modified": bulk_network_port_data
+                    "modified": bulk_network_port_data,
                 }
             )
     # all network connections are modifications,
@@ -1571,88 +1075,62 @@ def network_bulk_upload(request):
     response = {
         "added": 0,
         "ignored": num_ports_ignored,
-        "modifications": modifications_to_approve
+        "modifications": modifications_to_approve,
     }
     log_bulk_upload(
         request.user,
         ElementType.NETWORK_CONNECTIONS,
         0,
         num_ports_ignored,
-        len(modifications_to_approve)
+        len(modifications_to_approve),
     )
-    return JsonResponse(
-        response,
-        status=HTTPStatus.OK
-    )
+    return JsonResponse(response, status=HTTPStatus.OK)
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def network_bulk_approve(request):
     data = JSONParser().parse(request)
-    if 'approved_modifications' not in data:
+    if "approved_modifications" not in data:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.IMPORT_ERROR.value +
-                    BulkFailure.IMPORT.value,
-                "errors":
-                    "Bulk approve request should have a parameter " +
-                    "'approved_modifications'"
+                "failure_message": Status.IMPORT_ERROR.value + BulkFailure.IMPORT.value,
+                "errors": "Bulk approve request should have a parameter "
+                + "'approved_modifications'",
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
-    network_datas = data['approved_modifications']
+    network_datas = data["approved_modifications"]
     warning_message = ""
     for network_data in network_datas:
-        source_asset = Asset.objects.get(
-            hostname=network_data['src_hostname']
-        )
+        source_asset = Asset.objects.get(hostname=network_data["src_hostname"])
         source_asset_data = RecursiveAssetSerializer(source_asset).data
-        mac_address, network_connection = normalize_bulk_network_data(
-            network_data
-        )
-        source_asset_data['mac_addresses'] = mac_address
-        source_asset_data['network_connections'] = network_connection
+        mac_address, network_connection = normalize_bulk_network_data(network_data)
+        source_asset_data["mac_addresses"] = mac_address
+        source_asset_data["network_connections"] = network_connection
         try:
-            save_mac_addresses(
-                asset_data=source_asset_data,
-                asset_id=source_asset.id
-            )
+            save_mac_addresses(asset_data=source_asset_data, asset_id=source_asset.id)
         except MacAddressException as error:
-            warning_message += \
-                "Some mac addresses couldn't be saved. " + \
-                str(error)
+            warning_message += "Some mac addresses couldn't be saved. " + str(error)
         try:
             save_network_connections(
-                asset_data=source_asset_data,
-                asset_id=source_asset.id
+                asset_data=source_asset_data, asset_id=source_asset.id
             )
         except NetworkConnectionException as error:
-            warning_message += \
-                "Some network connections couldn't be saved. " + \
-                str(error)
-    log_bulk_approve(
-        request.user,
-        ElementType.NETWORK_CONNECTIONS,
-        len(network_datas)
-    )
+            warning_message += "Some network connections couldn't be saved. " + str(
+                error
+            )
+    log_bulk_approve(request.user, ElementType.NETWORK_CONNECTIONS, len(network_datas))
     if warning_message:
-        return JsonResponse(
-            {"warning_message": warning_message},
-            status=HTTPStatus.OK,
-        )
+        return JsonResponse({"warning_message": warning_message}, status=HTTPStatus.OK,)
     else:
         return JsonResponse(
-            {
-                "success_message":
-                    "All network connections created succesfully."
-            },
+            {"success_message": "All network connections created succesfully."},
             status=HTTPStatus.OK,
         )
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def network_bulk_export(request):
     assets_query = Asset.objects
@@ -1661,11 +1139,11 @@ def network_bulk_export(request):
     except Exception as error:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.EXPORT_ERROR.value + GenericFailure.FILTER.value,
-                "errors": str(error)
+                "failure_message": Status.EXPORT_ERROR.value
+                + GenericFailure.FILTER.value,
+                "errors": str(error),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     for filter_arg in filter_args:
         assets_query = assets_query.filter(**filter_arg)
@@ -1675,11 +1153,11 @@ def network_bulk_export(request):
     except Exception as error:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.EXPORT_ERROR.value + GenericFailure.SORT.value,
-                "errors": str(error)
+                "failure_message": Status.EXPORT_ERROR.value
+                + GenericFailure.SORT.value,
+                "errors": str(error),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     assets = assets_query.order_by(*sort_args)
     all_ports = []
@@ -1694,13 +1172,10 @@ def network_bulk_export(request):
     csv_writer = csv.DictWriter(csv_string, fields)
     csv_writer.writeheader()
     csv_writer.writerows(serializer.data)
-    return JsonResponse(
-        {"export_csv": csv_string.getvalue()},
-        status=HTTPStatus.OK,
-    )
+    return JsonResponse({"export_csv": csv_string.getvalue()}, status=HTTPStatus.OK,)
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def asset_page_count(request):
     """
@@ -1718,38 +1193,36 @@ def asset_page_count(request):
         return get_page_count_response_for_cp(request, change_plan)
     else:
         return get_page_count_response(
-            Asset,
-            request.query_params,
-            data_for_filters=request.data,
+            Asset, request.query_params, data_for_filters=request.data,
         )
 
 
-@api_view(['GET'])
+@api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def asset_fields(request):
     """
     Return all fields on the AssetSerializer.
     """
     return JsonResponse(
-        {"fields": [
-            'asset_number',
-            'hostname',
-            'model',
-            'rack',
-            'rack_position',
-            'owner',
-            'comment',
-        ]},
+        {
+            "fields": [
+                "asset_number",
+                "hostname",
+                "model",
+                "rack",
+                "rack_position",
+                "owner",
+                "comment",
+            ]
+        },
         status=HTTPStatus.OK,
     )
 
 
-@api_view(['GET'])
+@api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def asset_number(request):
     """
     Get a suggest asset number for Asset creation
     """
-    return JsonResponse(
-        {"asset_number": get_next_available_asset_number()}
-    )
+    return JsonResponse({"asset_number": get_next_available_asset_number()})

--- a/rackcity/views/change_plan_views.py
+++ b/rackcity/views/change_plan_views.py
@@ -11,6 +11,7 @@ from rackcity.models import (
     AssetCP,
 )
 from rackcity.utils.change_planner_utils import (
+    get_change_plan,
     get_modifications_in_cp,
     asset_cp_has_conflicts,
     get_cp_already_executed_response,
@@ -36,7 +37,6 @@ from rackcity.utils.query_utils import (
     get_page_count_response,
     get_many_response,
 )
-from rackcity.views.rackcity_utils import get_change_plan
 from rest_framework.decorators import permission_classes, api_view
 from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated

--- a/rackcity/views/decommission_views.py
+++ b/rackcity/views/decommission_views.py
@@ -8,6 +8,7 @@ from rackcity.api.serializers import (
 from rackcity.models import Asset, DecommissionedAsset, AssetCP
 from rackcity.permissions.permissions import user_has_asset_permission
 from rackcity.utils.change_planner_utils import (
+    get_change_plan,
     get_cp_already_executed_response,
     get_many_assets_response_for_cp,
     get_page_count_response_for_decommissioned_cp,
@@ -27,7 +28,6 @@ from rackcity.utils.query_utils import (
     get_many_response,
     get_page_count_response,
 )
-from rackcity.views.rackcity_utils import get_change_plan
 from rest_framework.decorators import permission_classes, api_view
 from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated

--- a/rackcity/views/it_model_views.py
+++ b/rackcity/views/it_model_views.py
@@ -1,14 +1,31 @@
-from rest_framework.parsers import JSONParser
+from base64 import b64decode
+import csv
 from django.http import HttpResponse, JsonResponse
 from django.contrib.auth.decorators import permission_required
 from django.core.exceptions import ObjectDoesNotExist
-from rackcity.models import ITModel, Asset
+from http import HTTPStatus
+from io import StringIO, BytesIO
 from rackcity.api.serializers import (
     RecursiveAssetSerializer,
     RecursiveAssetCPSerializer,
     ITModelSerializer,
     BulkITModelSerializer,
-    normalize_bulk_model_data
+    normalize_bulk_model_data,
+)
+from rackcity.models import ITModel, Asset
+from rackcity.models.asset import get_assets_for_cp
+from rackcity.permissions.permissions import PermissionPath
+from rackcity.utils.change_planner_utils import get_change_plan
+from rackcity.utils.errors_utils import (
+    GenericFailure,
+    Status,
+    parse_serializer_errors,
+    parse_save_validation_error,
+    BulkFailure,
+)
+from rackcity.utils.exceptions import (
+    LocationException,
+    ModelModificationException,
 )
 from rackcity.utils.log_utils import (
     log_action,
@@ -18,134 +35,116 @@ from rackcity.utils.log_utils import (
     Action,
     ElementType,
 )
-from rackcity.utils.errors_utils import (
-    GenericFailure,
-    Status,
-    parse_serializer_errors,
-    parse_save_validation_error,
-    BulkFailure
-)
-from rackcity.models.asset import get_assets_for_cp
-from rackcity.permissions.permissions import PermissionPath
-from rest_framework.decorators import permission_classes, api_view
-from rest_framework.permissions import IsAuthenticated
-from http import HTTPStatus
-import csv
-from base64 import b64decode
-import re
-from io import StringIO, BytesIO
 from rackcity.utils.query_utils import (
     get_sort_arguments,
     get_filter_arguments,
     get_page_count_response,
     get_many_response,
 )
-from rackcity.views.rackcity_utils import (
+from rackcity.utils.rackcity_utils import (
     validate_asset_location,
     records_are_identical,
-    LocationException,
-    ModelModificationException,
-    get_change_plan
 )
+import re
+from rest_framework.decorators import permission_classes, api_view
+from rest_framework.parsers import JSONParser
+from rest_framework.permissions import IsAuthenticated
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_required(PermissionPath.MODEL_WRITE.value, raise_exception=True)
 def model_add(request):
     """
     Add a new model
     """
     data = JSONParser().parse(request)
-    if 'id' in data:
+    if "id" in data:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.CREATE_ERROR.value + GenericFailure.INTERNAL.value,
-                "errors": "Don't include 'id' when creating a model"
+                "failure_message": Status.CREATE_ERROR.value
+                + GenericFailure.INTERNAL.value,
+                "errors": "Don't include 'id' when creating a model",
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     serializer = ITModelSerializer(data=data)
     if not serializer.is_valid(raise_exception=False):
         return JsonResponse(
             {
-                "failure_message":
-                    Status.INVALID_INPUT.value +
-                    parse_serializer_errors(serializer.errors),
-                "errors": str(serializer.errors)
+                "failure_message": Status.INVALID_INPUT.value
+                + parse_serializer_errors(serializer.errors),
+                "errors": str(serializer.errors),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     try:
         new_model = serializer.save()
     except Exception as error:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.CREATE_ERROR.value +
-                    parse_save_validation_error(error, "Model"),
-                "errors": str(error)
+                "failure_message": Status.CREATE_ERROR.value
+                + parse_save_validation_error(error, "Model"),
+                "errors": str(error),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     log_action(request.user, new_model, Action.CREATE)
     return JsonResponse(
         {
-            "success_message":
-                Status.SUCCESS.value +
-                new_model.vendor + " " + new_model.model_number +
-                " created"
+            "success_message": Status.SUCCESS.value
+            + new_model.vendor
+            + " "
+            + new_model.model_number
+            + " created"
         },
-        status=HTTPStatus.CREATED
+        status=HTTPStatus.CREATED,
     )
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_required(PermissionPath.MODEL_WRITE.value, raise_exception=True)
 def model_modify(request):
     """
     Modify an existing model
     """
     data = JSONParser().parse(request)
-    if 'id' not in data:
+    if "id" not in data:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.MODIFY_ERROR.value + GenericFailure.INTERNAL.value,
-                "errors": "Must include 'id' when modifying a model"
+                "failure_message": Status.MODIFY_ERROR.value
+                + GenericFailure.INTERNAL.value,
+                "errors": "Must include 'id' when modifying a model",
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
-    id = data['id']
+    id = data["id"]
     try:
         existing_model = ITModel.objects.get(id=id)
     except ObjectDoesNotExist:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.MODIFY_ERROR.value +
-                    "Model" + GenericFailure.DOES_NOT_EXIST.value,
-                "errors": "No existing model with id="+str(id)
+                "failure_message": Status.MODIFY_ERROR.value
+                + "Model"
+                + GenericFailure.DOES_NOT_EXIST.value,
+                "errors": "No existing model with id=" + str(id),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     try:
         validate_model_height_change(data, existing_model)
     except LocationException as error:
-        location_failure = "Height change of model causes conflicts. " + \
-            str(error)
+        location_failure = "Height change of model causes conflicts. " + str(error)
         return JsonResponse(
             {"failure_message": Status.MODIFY_ERROR.value + location_failure},
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     try:
         validate_model_change(data, existing_model)
     except ModelModificationException as error:
-        modification_failure = str(
-            error) + " There are existing assets with this model"
+        modification_failure = str(error) + " There are existing assets with this model"
         return JsonResponse(
             {"failure_message": Status.MODIFY_ERROR.value + modification_failure},
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     for field in data.keys():
         setattr(existing_model, field, data[field])
@@ -154,22 +153,22 @@ def model_modify(request):
     except Exception as error:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.MODIFY_ERROR.value +
-                    parse_save_validation_error(error, "Model"),
-                "errors": str(error)
+                "failure_message": Status.MODIFY_ERROR.value
+                + parse_save_validation_error(error, "Model"),
+                "errors": str(error),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     log_action(request.user, existing_model, Action.MODIFY)
     return JsonResponse(
         {
-            "success_message":
-                Status.SUCCESS.value +
-                existing_model.vendor + " " + existing_model.model_number +
-                " modified"
+            "success_message": Status.SUCCESS.value
+            + existing_model.vendor
+            + " "
+            + existing_model.model_number
+            + " modified"
         },
-        status=HTTPStatus.OK
+        status=HTTPStatus.OK,
     )
 
 
@@ -181,49 +180,34 @@ def validate_model_change(new_model_data, existing_model):
         return
     assets = Asset.objects.filter(model=existing_model.id)
     if len(assets) > 0:
-        if (
-            new_model_data["network_ports"]
-            or existing_model.network_ports
-        ):
+        if new_model_data["network_ports"] or existing_model.network_ports:
             if (
-                (
-                    not new_model_data["network_ports"]
-                    and existing_model.network_ports
-                )
+                (not new_model_data["network_ports"] and existing_model.network_ports)
                 or (
-                    new_model_data["network_ports"]
-                    and not existing_model.network_ports
+                    new_model_data["network_ports"] and not existing_model.network_ports
                 )
                 or (
                     set(new_model_data["network_ports"])
                     != set(existing_model.network_ports)
                 )
             ):
-                raise ModelModificationException(
-                    "Unable to modify network ports. ")
-        if (
-            new_model_data["num_power_ports"]
-            or existing_model.num_power_ports
-        ):
+                raise ModelModificationException("Unable to modify network ports. ")
+        if new_model_data["num_power_ports"] or existing_model.num_power_ports:
             if (
-                (
-                    not new_model_data["num_power_ports"]
-                    and existing_model.num_power_ports
-                )
-                or (
-                    int(new_model_data["num_power_ports"])
-                    != existing_model.num_power_ports
-                )
+                not new_model_data["num_power_ports"] and existing_model.num_power_ports
+            ) or (
+                int(new_model_data["num_power_ports"]) != existing_model.num_power_ports
             ):
                 raise ModelModificationException(
-                    "Unable to modify number of power ports. ")
+                    "Unable to modify number of power ports. "
+                )
     return
 
 
 def validate_model_height_change(new_model_data, existing_model):
-    if 'height' not in new_model_data:
+    if "height" not in new_model_data:
         return
-    new_model_height = int(new_model_data['height'])
+    new_model_height = int(new_model_data["height"])
     if new_model_height <= existing_model.height:
         return
     else:
@@ -231,80 +215,72 @@ def validate_model_height_change(new_model_data, existing_model):
         for asset in assets:
             try:
                 validate_asset_location(
-                    asset.rack.id,
-                    asset.rack_position,
-                    new_model_height,
-                    asset.id
+                    asset.rack.id, asset.rack_position, new_model_height, asset.id
                 )
             except LocationException as error:
                 raise error
         return
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_required(PermissionPath.MODEL_WRITE.value, raise_exception=True)
 def model_delete(request):
     """
     Delete an existing model
     """
     data = JSONParser().parse(request)
-    if 'id' not in data:
+    if "id" not in data:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.DELETE_ERROR.value + GenericFailure.INTERNAL.value,
-                "errors": "Must include 'id' when deleting a model"
+                "failure_message": Status.DELETE_ERROR.value
+                + GenericFailure.INTERNAL.value,
+                "errors": "Must include 'id' when deleting a model",
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
-    id = data['id']
+    id = data["id"]
     try:
         existing_model = ITModel.objects.get(id=id)
     except ObjectDoesNotExist:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.DELETE_ERROR.value +
-                    "Model" + GenericFailure.DOES_NOT_EXIST.value,
-                "errors": "No existing model with id="+str(id)
+                "failure_message": Status.DELETE_ERROR.value
+                + "Model"
+                + GenericFailure.DOES_NOT_EXIST.value,
+                "errors": "No existing model with id=" + str(id),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     assets = Asset.objects.filter(model=id)
     if assets:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.DELETE_ERROR.value +
-                    "Cannot delete this model because assets of it exist"
+                "failure_message": Status.DELETE_ERROR.value
+                + "Cannot delete this model because assets of it exist"
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     try:
-        model_name = " ".join([
-            existing_model.vendor,
-            existing_model.model_number
-        ])
+        model_name = " ".join([existing_model.vendor, existing_model.model_number])
         existing_model.delete()
     except Exception as error:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.DELETE_ERROR.value +
-                    "Model" +
-                    GenericFailure.ON_DELETE.value,
-                "errors": str(error)
+                "failure_message": Status.DELETE_ERROR.value
+                + "Model"
+                + GenericFailure.ON_DELETE.value,
+                "errors": str(error),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     log_delete(request.user, ElementType.MODEL, model_name)
     return JsonResponse(
         {"success_message": Status.SUCCESS.value + model_name + " deleted"},
-        status=HTTPStatus.OK
+        status=HTTPStatus.OK,
     )
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def model_many(request):
     """
@@ -312,15 +288,10 @@ def model_many(request):
     models are returned. If page is specified as a query parameter, page
     size must also be specified, and a page of models will be returned.
     """
-    return get_many_response(
-        ITModel,
-        ITModelSerializer,
-        "models",
-        request,
-    )
+    return get_many_response(ITModel, ITModelSerializer, "models", request,)
 
 
-@api_view(['GET'])
+@api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def model_detail(request, id):
     """
@@ -332,99 +303,84 @@ def model_detail(request, id):
         assets_cp = []
         change_plan = None
         if request.query_params.get("change_plan"):
-            (change_plan, response) = get_change_plan(request.query_params.get("change_plan"))
+            (change_plan, response) = get_change_plan(
+                request.query_params.get("change_plan")
+            )
             if response:
                 return response
             assets, assets_cp = get_assets_for_cp(change_plan.id)
             assets = assets.filter(model=id)
             assets_cp = assets_cp.filter(model=id, change_plan=change_plan.id)
-            assets_cp_serializer = RecursiveAssetCPSerializer(
-                assets_cp,
-                many=True
-            )
+            assets_cp_serializer = RecursiveAssetCPSerializer(assets_cp, many=True)
 
         else:
             assets = Asset.objects.filter(model=id)
-        assets_serializer = RecursiveAssetSerializer(
-            assets,
-            many=True,
-        )
+        assets_serializer = RecursiveAssetSerializer(assets, many=True,)
 
         if change_plan:
             asset_data = assets_serializer.data + assets_cp_serializer.data
         else:
-            asset_data = assets_serializer.data 
-        model_detail = {
-            "model": model_serializer.data,
-            "assets": asset_data
-        }
+            asset_data = assets_serializer.data
+        model_detail = {"model": model_serializer.data, "assets": asset_data}
         return JsonResponse(model_detail, status=HTTPStatus.OK)
     except ITModel.DoesNotExist:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.ERROR.value +
-                    "Model" + GenericFailure.DOES_NOT_EXIST.value,
-                "errors": "No existing model with id="+str(id)
+                "failure_message": Status.ERROR.value
+                + "Model"
+                + GenericFailure.DOES_NOT_EXIST.value,
+                "errors": "No existing model with id=" + str(id),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
 
 
-@api_view(['GET'])
+@api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def model_vendors(request):
     """
     Get all known vendors.
     """
-    vendors_names = [name for name in ITModel.objects.values_list(
-        'vendor', flat=True).distinct('vendor')]
-    return JsonResponse(
-        {"vendors": vendors_names},
-        status=HTTPStatus.OK,
-    )
+    vendors_names = [
+        name
+        for name in ITModel.objects.values_list("vendor", flat=True).distinct("vendor")
+    ]
+    return JsonResponse({"vendors": vendors_names}, status=HTTPStatus.OK,)
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_required(PermissionPath.MODEL_WRITE.value, raise_exception=True)
 def model_bulk_upload(request):
     """
     Bulk upload many models to add or modify
     """
     data = JSONParser().parse(request)
-    if 'import_csv' not in data:
+    if "import_csv" not in data:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.IMPORT_ERROR.value +
-                    BulkFailure.IMPORT.value,
-                "errors":
-                    "Bulk upload request should have a parameter 'file'"
+                "failure_message": Status.IMPORT_ERROR.value + BulkFailure.IMPORT.value,
+                "errors": "Bulk upload request should have a parameter 'file'",
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
-    base_64_csv = data['import_csv']
-    csv_bytes_io = BytesIO(
-        b64decode(re.sub(".*base64,", '', base_64_csv))
-    )
-    csv_string_io = StringIO(csv_bytes_io.read().decode('UTF-8-SIG'))
-    csvReader = csv.DictReader(csv_string_io)
+    base_64_csv = data["import_csv"]
+    csv_bytes_io = BytesIO(b64decode(re.sub(".*base64,", "", base_64_csv)))
+    csv_string_io = StringIO(csv_bytes_io.read().decode("UTF-8-SIG"))
+    csv_reader = csv.DictReader(csv_string_io)
     expected_fields = BulkITModelSerializer.Meta.fields
-    given_fields = csvReader.fieldnames
-    if (
-        len(expected_fields) != len(given_fields)  # check for repeated fields
-        or set(expected_fields) != set(given_fields)
-    ):
+    given_fields = csv_reader.fieldnames
+    if len(expected_fields) != len(given_fields) or set(  # check for repeated fields
+        expected_fields
+    ) != set(given_fields):
         return JsonResponse(
             {
-                "failure_message":
-                    Status.IMPORT_ERROR.value +
-                    BulkFailure.IMPORT_COLUMNS.value
+                "failure_message": Status.IMPORT_ERROR.value
+                + BulkFailure.IMPORT_COLUMNS.value
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     bulk_model_datas = []
-    for row in csvReader:
+    for row in csv_reader:
         bulk_model_datas.append(dict(row))
     models_to_add = []
     potential_modifications = []
@@ -435,36 +391,31 @@ def model_bulk_upload(request):
         if not model_serializer.is_valid():
             return JsonResponse(
                 {
-                    "failure_message":
-                        Status.IMPORT_ERROR.value +
-                        BulkFailure.MODEL_INVALID.value +
-                        parse_serializer_errors(model_serializer.errors),
-                    "errors": str(model_serializer.errors)
+                    "failure_message": Status.IMPORT_ERROR.value
+                    + BulkFailure.MODEL_INVALID.value
+                    + parse_serializer_errors(model_serializer.errors),
+                    "errors": str(model_serializer.errors),
                 },
-                status=HTTPStatus.BAD_REQUEST
+                status=HTTPStatus.BAD_REQUEST,
             )
-        if (
-            (model_data['vendor'], model_data['model_number'])
-            in models_in_import
-        ):
-            failure_message = Status.IMPORT_ERROR.value + \
-                "Vendor+model_number combination must be unique, but " + \
-                "vendor="+model_data['vendor'] + \
-                ", model_number="+model_data['model_number'] + \
-                " appears more than once in import. "
+        if (model_data["vendor"], model_data["model_number"]) in models_in_import:
+            failure_message = (
+                Status.IMPORT_ERROR.value
+                + "Vendor+model_number combination must be unique, but "
+                + "vendor="
+                + model_data["vendor"]
+                + ", model_number="
+                + model_data["model_number"]
+                + " appears more than once in import. "
+            )
             return JsonResponse(
-                {"failure_message": failure_message},
-                status=HTTPStatus.BAD_REQUEST
+                {"failure_message": failure_message}, status=HTTPStatus.BAD_REQUEST
             )
         else:
-            models_in_import.add(
-                (model_data['vendor'],
-                 model_data['model_number'])
-            )
+            models_in_import.add((model_data["vendor"], model_data["model_number"]))
         try:
             existing_model = ITModel.objects.get(
-                vendor=model_data['vendor'],
-                model_number=model_data['model_number']
+                vendor=model_data["vendor"], model_number=model_data["model_number"]
             )
         except ObjectDoesNotExist:
             models_to_add.append(model_serializer)
@@ -472,33 +423,44 @@ def model_bulk_upload(request):
             try:
                 validate_model_height_change(model_data, existing_model)
             except LocationException as error:
-                failure_message = Status.IMPORT_ERROR.value + \
-                    "Height change of this model causes conflicts: " + \
-                    "vendor="+model_data['vendor'] + \
-                    ", model_number="+model_data['model_number'] + \
-                    ". " + \
-                    str(error)
+                failure_message = (
+                    Status.IMPORT_ERROR.value
+                    + "Height change of this model causes conflicts: "
+                    + "vendor="
+                    + model_data["vendor"]
+                    + ", model_number="
+                    + model_data["model_number"]
+                    + ". "
+                    + str(error)
+                )
                 return JsonResponse(
                     {"failure_message": failure_message},
-                    status=HTTPStatus.NOT_ACCEPTABLE
+                    status=HTTPStatus.NOT_ACCEPTABLE,
                 )
             try:
                 validate_model_change(model_data, existing_model)
             except ModelModificationException as error:
-                modification_failure = " There are existing assets with this model: " + \
-                    "vendor="+model_data['vendor'] + \
-                    ", model_number="+model_data['model_number'] + \
-                    ". " + str(error)
+                modification_failure = (
+                    " There are existing assets with this model: "
+                    + "vendor="
+                    + model_data["vendor"]
+                    + ", model_number="
+                    + model_data["model_number"]
+                    + ". "
+                    + str(error)
+                )
                 return JsonResponse(
-                    {"failure_message": Status.MODIFY_ERROR.value +
-                        modification_failure},
-                    status=HTTPStatus.BAD_REQUEST
+                    {
+                        "failure_message": Status.MODIFY_ERROR.value
+                        + modification_failure
+                    },
+                    status=HTTPStatus.BAD_REQUEST,
                 )
 
             potential_modifications.append(
                 {
                     "existing_model": existing_model,
-                    "new_data": model_serializer.validated_data
+                    "new_data": model_serializer.validated_data,
                 }
             )
     records_added = 0
@@ -508,22 +470,17 @@ def model_bulk_upload(request):
     records_ignored = 0
     modifications_to_approve = []
     for potential_modification in potential_modifications:
-        new_data = potential_modification['new_data']
-        existing_data = ITModelSerializer(
-            potential_modification['existing_model']
-        ).data
+        new_data = potential_modification["new_data"]
+        existing_data = ITModelSerializer(potential_modification["existing_model"]).data
         if records_are_identical(existing_data, new_data):
             records_ignored += 1
         else:
-            new_data['id'] = potential_modification['existing_model'].id
+            new_data["id"] = potential_modification["existing_model"].id
             for field in existing_data.keys():
                 if field not in new_data:
                     new_data[field] = None
             modifications_to_approve.append(
-                {
-                    "existing": existing_data,
-                    "modified": new_data
-                }
+                {"existing": existing_data, "modified": new_data}
             )
     log_bulk_upload(
         request.user,
@@ -536,51 +493,50 @@ def model_bulk_upload(request):
         {
             "added": records_added,
             "ignored": records_ignored,
-            "modifications": modifications_to_approve
+            "modifications": modifications_to_approve,
         },
-        status=HTTPStatus.OK
+        status=HTTPStatus.OK,
     )
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_required(PermissionPath.MODEL_WRITE.value, raise_exception=True)
 def model_bulk_approve(request):
     """
     Bulk approve many models to modify
     """
     data = JSONParser().parse(request)
-    if 'approved_modifications' not in data:
+    if "approved_modifications" not in data:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.IMPORT_ERROR.value +
-                    BulkFailure.IMPORT.value,
-                "errors":
-                    "Bulk approve request should have a parameter " +
-                    "'approved_modifications'"
+                "failure_message": Status.IMPORT_ERROR.value + BulkFailure.IMPORT.value,
+                "errors": "Bulk approve request should have a parameter "
+                + "'approved_modifications'",
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
-    model_datas = data['approved_modifications']
+    model_datas = data["approved_modifications"]
     for model_data in model_datas:
         model_serializer = ITModelSerializer(data=model_data)
         if not model_serializer.is_valid():
-            failure_message = "At least one modification was not valid. " + \
-                str(model_serializer.errors)
+            failure_message = "At least one modification was not valid. " + str(
+                model_serializer.errors
+            )
             return JsonResponse(
-                {"failure_message": failure_message},
-                status=HTTPStatus.BAD_REQUEST
+                {"failure_message": failure_message}, status=HTTPStatus.BAD_REQUEST
             )
     for model_data in model_datas:
-        existing_model = ITModel.objects.get(id=model_data['id'])
-        for field in model_data.keys():  # This is assumed to have all fields, and with null values for blank ones. That's how it's returned in bulk-upload
+        existing_model = ITModel.objects.get(id=model_data["id"])
+        for field in model_data.keys():
+            # This is assumed to have all fields, and with null values for blank ones,
+            # that's how it's returned in bulk-upload
             setattr(existing_model, field, model_data[field])
         existing_model.save()
     log_bulk_approve(request.user, ElementType.MODEL, len(model_datas))
     return HttpResponse(status=HTTPStatus.OK)
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def model_bulk_export(request):
     """
@@ -593,11 +549,11 @@ def model_bulk_export(request):
     except Exception as error:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.EXPORT_ERROR.value + GenericFailure.FILTER.value,
-                "errors": str(error)
+                "failure_message": Status.EXPORT_ERROR.value
+                + GenericFailure.FILTER.value,
+                "errors": str(error),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     for filter_arg in filter_args:
         models_query = models_query.filter(**filter_arg)
@@ -607,11 +563,11 @@ def model_bulk_export(request):
     except Exception as error:
         return JsonResponse(
             {
-                "failure_message":
-                    Status.EXPORT_ERROR.value + GenericFailure.SORT.value,
-                "errors": str(error)
+                "failure_message": Status.EXPORT_ERROR.value
+                + GenericFailure.SORT.value,
+                "errors": str(error),
             },
-            status=HTTPStatus.BAD_REQUEST
+            status=HTTPStatus.BAD_REQUEST,
         )
     models = models_query.order_by(*sort_args)
 
@@ -621,13 +577,10 @@ def model_bulk_export(request):
     csv_writer = csv.DictWriter(csv_string, fields)
     csv_writer.writeheader()
     csv_writer.writerows(serializer.data)
-    return JsonResponse(
-        {"export_csv": csv_string.getvalue()},
-        status=HTTPStatus.OK,
-    )
+    return JsonResponse({"export_csv": csv_string.getvalue()}, status=HTTPStatus.OK,)
 
 
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def model_page_count(request):
     """
@@ -635,30 +588,30 @@ def model_page_count(request):
     specified as query parameter.
     """
     return get_page_count_response(
-        ITModel,
-        request.query_params,
-        data_for_filters=request.data,
+        ITModel, request.query_params, data_for_filters=request.data,
     )
 
 
-@api_view(['GET'])
+@api_view(["GET"])
 def model_fields(request):
     """
     Return all fields on the ITModelSerializer.
     """
     return JsonResponse(
-        {"fields": [
-            'vendor',
-            'model_number',
-            'height',
-            'display_color',
-            'num_network_ports',
-            'network_ports',
-            'num_power_ports',
-            'cpu',
-            'memory_gb',
-            'storage',
-            'comment',
-        ]},
+        {
+            "fields": [
+                "vendor",
+                "model_number",
+                "height",
+                "display_color",
+                "num_network_ports",
+                "network_ports",
+                "num_power_ports",
+                "cpu",
+                "memory_gb",
+                "storage",
+                "comment",
+            ]
+        },
         status=HTTPStatus.OK,
     )

--- a/rackcity/views/pdu_views.py
+++ b/rackcity/views/pdu_views.py
@@ -28,7 +28,7 @@ import requests
 import time
 from requests.exceptions import ConnectionError
 from rackcity.models.asset import get_assets_for_cp
-from rackcity.views.rackcity_utils import get_change_plan
+from rackcity.utils.change_planner_utils import get_change_plan
 pdu_url = 'http://hyposoft-mgt.colab.duke.edu:8005/'
 # Need to specify rack + side in request, e.g. for A1 left, use A01L
 get_pdu = 'pdu.php?pdu=hpdu-rtp1-'

--- a/rackcity/views/rack_views.py
+++ b/rackcity/views/rack_views.py
@@ -21,7 +21,7 @@ from rackcity.utils.errors_utils import (
 from rest_framework.decorators import permission_classes, api_view
 from rest_framework.permissions import IsAuthenticated
 from http import HTTPStatus
-from rackcity.views.rackcity_utils import get_rack_detailed_response
+from rackcity.utils.rackcity_utils import get_rack_detailed_response
 
 
 @api_view(['GET'])


### PR DESCRIPTION
Ok so it looks like there are an insane amount of line changes BUT I promise it is all auto-reformatting except for A LITTLE BIT of moving around of imports due to clean up of utils files 

The ONLY refactoring is moving existing code to different places. Nothing was rewritten/refactored otherwise

Changes:
1. LINTING (including alphabetical imports) 
2. Moved custom exceptions to new utils file: `/utils/exceptions.py`
3. Moved asset view helper methods to new utils file: `/utils/asset_utils.py`
4. Moved `rackcity_utils.py` from views folder to utils folder
5. Moved some stuff from `rackcity_utils.py` to more specific/relevant utils folders 
6. Renamed some variables, changing CP to _cp and decomissioned to decommissioned