### PR TITLE
can't delete a model that is used on cp

### DIFF
--- a/rackcity/models/asset.py
+++ b/rackcity/models/asset.py
@@ -71,8 +71,10 @@ def validate_hostname_uniqueness(value, asset_id, change_plan, related_asset):
         related_asset_id = related_asset.id
 
     matching_assets = assets.filter(hostname=value)
-    if len(matching_assets) > 0 and not (
-        related_asset and matching_assets[0].id == related_asset_id
+    if (
+        value
+        and len(matching_assets) > 0
+        and not (related_asset and matching_assets[0].id == related_asset_id)
     ):
         raise ValidationError(
             "'"
@@ -313,11 +315,7 @@ class AssetCP(AbstractAsset):
         blank=True,
     )
     chassis = models.ForeignKey(
-        "self",
-        on_delete=models.CASCADE,
-        verbose_name="chassis",
-        null=True,
-        blank=True,
+        "self", on_delete=models.CASCADE, verbose_name="chassis", null=True, blank=True,
     )
     differs_from_live = models.BooleanField(default=False, blank=True)
 

--- a/rackcity/views/it_model_views.py
+++ b/rackcity/views/it_model_views.py
@@ -14,7 +14,7 @@ from rackcity.api.serializers import (
     normalize_bulk_model_data,
 )
 from rackcity.models import ITModel, Asset, validate_ports, validate_height
-from rackcity.models.asset import get_assets_for_cp
+from rackcity.models.asset import get_assets_for_cp, AssetCP
 from rackcity.permissions.permissions import PermissionPath
 from rackcity.utils.change_planner_utils import get_change_plan
 from rackcity.utils.errors_utils import (
@@ -264,6 +264,15 @@ def model_delete(request):
             {
                 "failure_message": Status.DELETE_ERROR.value
                 + "Cannot delete this model because assets of it exist"
+            },
+            status=HTTPStatus.BAD_REQUEST,
+        )
+    assets_cp = AssetCP.objects.filter(model=id)
+    if assets_cp:
+        return JsonResponse(
+            {
+                "failure_message": Status.DELETE_ERROR.value
+                + "Cannot delete this model because assets of it exist on change plan(s)"
             },
             status=HTTPStatus.BAD_REQUEST,
         )


### PR DESCRIPTION
we technically got on VR for this last eval, just didn't implement it

much easier to just not allow deletion bc we assume that an asset has model everywhere in our code 